### PR TITLE
IN-subquery (semi-join) permissions + native docker dev method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "job-runner"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "sp00ky-cli"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "argon2",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-ffi"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "libc",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-protocol"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "blake3",
  "serde",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-wasm"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "job-runner"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "sp00ky-cli"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "argon2",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-ffi"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "libc",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-protocol"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "blake3",
  "serde",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-wasm"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "job-runner"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "sp00ky-cli"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "argon2",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-ffi"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "libc",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-protocol"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "blake3",
  "serde",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-wasm"
-version = "0.0.1-canary.104"
+version = "0.0.1-canary.105"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/benchmark",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Performance benchmark CLI for sp00ky scheduler + SSP",
   "private": true,
   "type": "module",

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/benchmark",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Performance benchmark CLI for sp00ky scheduler + SSP",
   "private": true,
   "type": "module",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp00ky-cli"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 
 [[bin]]

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp00ky-cli"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 
 [[bin]]

--- a/apps/cli/npm/cli-darwin-arm64/package.json
+++ b/apps/cli/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-arm64",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "macOS Apple Silicon binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-darwin-arm64/package.json
+++ b/apps/cli/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-arm64",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "macOS Apple Silicon binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-darwin-x64/package.json
+++ b/apps/cli/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-x64",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "macOS Intel binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-darwin-x64/package.json
+++ b/apps/cli/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-x64",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "macOS Intel binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-arm64/package.json
+++ b/apps/cli/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-arm64",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Linux ARM64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-arm64/package.json
+++ b/apps/cli/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-arm64",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Linux ARM64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-x64/package.json
+++ b/apps/cli/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-x64",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Linux x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-x64/package.json
+++ b/apps/cli/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-x64",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Linux x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-win32-x64/package.json
+++ b/apps/cli/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-win32-x64",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Windows x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-win32-x64/package.json
+++ b/apps/cli/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-win32-x64",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Windows x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Generate TypeScript/Dart types from SurrealDB schema files",
   "type": "module",
   "main": "./dist/syncgen.cjs",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Generate TypeScript/Dart types from SurrealDB schema files",
   "type": "module",
   "main": "./dist/syncgen.cjs",

--- a/apps/cli/src/backend.rs
+++ b/apps/cli/src/backend.rs
@@ -1263,8 +1263,20 @@ pub enum BackendDevTypedConfig {
         file: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         workdir: Option<String>,
+        /// Single published port (host:container). Kept for back-compat; for
+        /// more than one use `ports`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         port: Option<String>,
+        /// Additional published ports (host:container), e.g. a REST + a gRPC
+        /// port. Merged with `port`. Lets a backend that listens on two ports
+        /// (like a relay with WS + gRPC) run through the native docker method.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ports: Option<Vec<String>>,
+        /// docker `--platform` for build + run, e.g. `linux/arm64` to run the
+        /// image's toolchain natively on Apple Silicon instead of emulating the
+        /// deploy (amd64) arch under QEMU.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        platform: Option<String>,
     },
     #[serde(rename = "uv")]
     Uv {

--- a/apps/cli/src/dev.rs
+++ b/apps/cli/src/dev.rs
@@ -67,15 +67,17 @@ fn collect_dev_ports(
 
     let mut collect_app = |label: &str, name: &str, dev: &Option<BackendDevConfig>| {
         if let Some(BackendDevConfig::Typed(BackendDevTypedConfig::Docker {
-            port: Some(p), ..
+            port, ports, ..
         })) = dev
         {
-            match port_check::parse_docker_host_port(p) {
-                Some(host) => out.push((host, format!("{}:{}", label, name))),
-                None => eprintln!(
-                    "{} Warning: could not parse docker port spec '{}' for {} '{}', skipping pre-check for it",
-                    PREFIX, p, label, name
-                ),
+            for p in merge_docker_ports(port.as_deref(), ports.as_deref()) {
+                match port_check::parse_docker_host_port(&p) {
+                    Some(host) => out.push((host, format!("{}:{}", label, name))),
+                    None => eprintln!(
+                        "{} Warning: could not parse docker port spec '{}' for {} '{}', skipping pre-check for it",
+                        PREFIX, p, label, name
+                    ),
+                }
             }
         }
     };
@@ -1882,6 +1884,31 @@ impl SupervisedService {
 }
 
 #[cfg(test)]
+mod docker_port_tests {
+    use super::*;
+
+    #[test]
+    fn merges_single_port_and_array() {
+        // A relay listening on WS + gRPC publishes both host ports.
+        let merged = merge_docker_ports(
+            Some("3670:3670"),
+            Some(&["3671:3671".to_string()]),
+        );
+        assert_eq!(merged, vec!["3670:3670".to_string(), "3671:3671".to_string()]);
+    }
+
+    #[test]
+    fn handles_only_ports_array_or_only_single() {
+        assert_eq!(
+            merge_docker_ports(None, Some(&["3670:3670".into(), "3671:3671".into()])),
+            vec!["3670:3670".to_string(), "3671:3671".to_string()]
+        );
+        assert_eq!(merge_docker_ports(Some("80:80"), None), vec!["80:80".to_string()]);
+        assert!(merge_docker_ports(None, None).is_empty());
+    }
+}
+
+#[cfg(test)]
 mod supervisor_tests {
     use super::*;
 
@@ -2173,12 +2200,16 @@ fn spawn_frontend_dev(
                     file,
                     workdir,
                     port,
+                    ports,
+                    platform,
                 }) => {
                     let cwd = resolve_workdir(project_dir, workdir.as_deref());
+                    let all_ports = merge_docker_ports(port.as_deref(), ports.as_deref());
                     println!("{} Building: docker build -f {}", prefix, file);
                     return spawn_docker_dev(
                         file,
-                        port.as_deref(),
+                        &all_ports,
+                        platform.as_deref(),
                         &envs,
                         &cwd,
                         "frontend",
@@ -2317,12 +2348,16 @@ fn spawn_backend_dev_commands(
                 file,
                 workdir,
                 port,
+                ports,
+                platform,
             }) => {
                 let cwd = resolve_workdir(project_dir, workdir.as_deref());
+                let all_ports = merge_docker_ports(port.as_deref(), ports.as_deref());
                 println!("{} Building: docker build -f {}", prefix, file);
                 guards.push(spawn_docker_dev(
                     file,
-                    port.as_deref(),
+                    &all_ports,
+                    platform.as_deref(),
                     &envs,
                     &cwd,
                     name,
@@ -2680,9 +2715,23 @@ fn spawn_prefixed(cmd: &mut Command, prefix: &str) -> LogTailGuard {
     }
 }
 
+/// Merge the single `port` field and the `ports` array into one host:container
+/// list, so a backend that listens on more than one port can be published.
+fn merge_docker_ports(port: Option<&str>, ports: Option<&[String]>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(p) = port {
+        out.push(p.to_string());
+    }
+    if let Some(ps) = ports {
+        out.extend(ps.iter().cloned());
+    }
+    out
+}
+
 fn spawn_docker_dev(
     file: &str,
-    port: Option<&str>,
+    ports: &[String],
+    platform: Option<&str>,
     envs: &[(String, String)],
     cwd: &Path,
     name: &str,
@@ -2691,9 +2740,17 @@ fn spawn_docker_dev(
     let tag = format!("sp00ky-dev-{}", name);
     let container_name = format!("sp00ky-dev-app-{}", name);
 
-    // Build the image (blocking, with prefixed output)
+    // Build the image (blocking, with prefixed output). `--platform` (when set)
+    // builds for the host arch so the image's toolchain runs natively instead
+    // of under QEMU emulation of the deploy arch.
+    let mut build_args: Vec<String> = vec!["build".into()];
+    if let Some(p) = platform {
+        build_args.push("--platform".into());
+        build_args.push(p.to_string());
+    }
+    build_args.extend(["-f".into(), file.to_string(), "-t".into(), tag.clone(), ".".into()]);
     let build_result = Command::new("docker")
-        .args(["build", "-f", file, "-t", &tag, "."])
+        .args(&build_args)
         .current_dir(cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -2736,9 +2793,16 @@ fn spawn_docker_dev(
         NETWORK_NAME.to_string(),
     ];
 
-    if let Some(p) = port {
-        args.push("-p".to_string());
+    if let Some(p) = platform {
+        args.push("--platform".to_string());
         args.push(p.to_string());
+    }
+
+    // Publish every requested host:container port (a backend may listen on
+    // more than one, e.g. REST + gRPC).
+    for p in ports {
+        args.push("-p".to_string());
+        args.push(p.clone());
     }
 
     // Pass resolved env vars as -e flags

--- a/apps/devtools-mcp/package.json
+++ b/apps/devtools-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools-mcp",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "MCP server for Sp00ky Sync devtools",
   "license": "MIT",
   "type": "module",

--- a/apps/devtools-mcp/package.json
+++ b/apps/devtools-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools-mcp",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "MCP server for Sp00ky Sync devtools",
   "license": "MIT",
   "type": "module",

--- a/apps/devtools/package.json
+++ b/apps/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Chrome DevTools extension for debugging and inspecting Sp00ky state",
   "private": true,
   "type": "module",

--- a/apps/devtools/package.json
+++ b/apps/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Chrome DevTools extension for debugging and inspecting Sp00ky state",
   "private": true,
   "type": "module",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,7 +1,7 @@
 {
   "name": "landing-page",
   "type": "module",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "scripts": {
     "dev": "astro dev",
     "dev:landingpage": "astro dev",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,7 +1,7 @@
 {
   "name": "landing-page",
   "type": "module",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "scripts": {
     "dev": "astro dev",
     "dev:landingpage": "astro dev",

--- a/apps/landing-page/public/schema/sp00ky.schema.json
+++ b/apps/landing-page/public/schema/sp00ky.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://sp00ky.cloud/schema/sp00ky.schema.json",
   "title": "sp00ky.yml",
-  "description": "Configuration file for Sp00ky — an offline-first, real-time sync framework built on SurrealDB.",
+  "description": "Configuration file for Sp00ky \u2014 an offline-first, real-time sync framework built on SurrealDB.",
   "type": "object",
   "properties": {
     "slug": {
@@ -13,7 +13,11 @@
     "mode": {
       "type": "string",
       "description": "Deployment mode.",
-      "enum": ["singlenode", "cluster", "surrealism"],
+      "enum": [
+        "singlenode",
+        "cluster",
+        "surrealism"
+      ],
       "default": "singlenode"
     },
     "surrealdb": {
@@ -39,8 +43,12 @@
           "type": "object",
           "description": "Individual versions for SSP and Scheduler (applies to all envs). Each is an image tag or a `{ path }` to a host-built binary.",
           "properties": {
-            "ssp":       { "$ref": "#/$defs/serviceVersion" },
-            "scheduler": { "$ref": "#/$defs/serviceVersion" }
+            "ssp": {
+              "$ref": "#/$defs/serviceVersion"
+            },
+            "scheduler": {
+              "$ref": "#/$defs/serviceVersion"
+            }
           },
           "additionalProperties": false
         },
@@ -48,8 +56,12 @@
           "type": "object",
           "description": "Per-environment versions. Currently only `dev` is consumed; `cloud` is reserved.",
           "properties": {
-            "dev":   { "$ref": "#/$defs/versionSpec" },
-            "cloud": { "$ref": "#/$defs/versionSpec" }
+            "dev": {
+              "$ref": "#/$defs/versionSpec"
+            },
+            "cloud": {
+              "$ref": "#/$defs/versionSpec"
+            }
           },
           "additionalProperties": false,
           "minProperties": 1
@@ -57,7 +69,7 @@
       ]
     },
     "logLevel": {
-      "description": "`RUST_LOG` directive applied to the Scheduler and SSP containers (both `spky dev` and `spky cloud deploy`). A plain string applies everywhere (e.g. `trace`, `info,ssp=debug`). A `{dev, cloud}` map sets per-environment levels. Unset → defaults to `info`.",
+      "description": "`RUST_LOG` directive applied to the Scheduler and SSP containers (both `spky dev` and `spky cloud deploy`). A plain string applies everywhere (e.g. `trace`, `info,ssp=debug`). A `{dev, cloud}` map sets per-environment levels. Unset \u2192 defaults to `info`.",
       "oneOf": [
         {
           "type": "string",
@@ -67,8 +79,14 @@
           "type": "object",
           "description": "Per-environment log level. `dev` is consumed by `spky dev`; `cloud` is sent to the cloud control plane on every deploy.",
           "properties": {
-            "dev":   { "type": "string", "description": "RUST_LOG directive used for local `spky dev` containers." },
-            "cloud": { "type": "string", "description": "RUST_LOG directive applied to the remote scheduler/SSP after `spky cloud deploy`." }
+            "dev": {
+              "type": "string",
+              "description": "RUST_LOG directive used for local `spky dev` containers."
+            },
+            "cloud": {
+              "type": "string",
+              "description": "RUST_LOG directive applied to the remote scheduler/SSP after `spky cloud deploy`."
+            }
           },
           "additionalProperties": false,
           "minProperties": 1
@@ -133,12 +151,17 @@
     "cloudApi": {
       "type": "string",
       "description": "Override the Sp00ky Cloud API endpoint (e.g. for staging).",
-      "examples": ["https://api-staging.sp00ky.cloud"]
+      "examples": [
+        "https://api-staging.sp00ky.cloud"
+      ]
     },
     "refMode": {
       "type": "string",
       "description": "Storage layout for the SSP's internal `_00_list_ref` table. 'dedicated' (default) gives each authenticated user their own `_00_list_ref_user_<id>` table; 'single' keeps the legacy shared `_00_list_ref`. Dedicated works around a SurrealDB v3 LIVE-permission gap on permission-gated tables.",
-      "enum": ["single", "dedicated"],
+      "enum": [
+        "single",
+        "dedicated"
+      ],
       "default": "dedicated"
     },
     "anonymousLiveQueries": {
@@ -152,12 +175,18 @@
     "versionSpec": {
       "description": "A version tag (string) or `{ssp, scheduler}` object. Used inside per-environment version splits.",
       "oneOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "object",
           "properties": {
-            "ssp":       { "$ref": "#/$defs/serviceVersion" },
-            "scheduler": { "$ref": "#/$defs/serviceVersion" }
+            "ssp": {
+              "$ref": "#/$defs/serviceVersion"
+            },
+            "scheduler": {
+              "$ref": "#/$defs/serviceVersion"
+            }
           },
           "additionalProperties": false
         }
@@ -173,7 +202,9 @@
         {
           "type": "object",
           "description": "Run a host-built binary instead of a published image.",
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "properties": {
             "path": {
               "type": "string",
@@ -206,13 +237,18 @@
         "hosting": {
           "type": "string",
           "description": "Whether SurrealDB is hosted on Sp00ky Cloud or externally.",
-          "enum": ["cloud", "external"],
+          "enum": [
+            "cloud",
+            "external"
+          ],
           "default": "cloud"
         },
         "endpoint": {
           "type": "string",
           "description": "SurrealDB endpoint URL. Required when hosting is \"external\".",
-          "examples": ["https://api.example.com"]
+          "examples": [
+            "https://api.example.com"
+          ]
         },
         "username": {
           "type": "string",
@@ -226,49 +262,78 @@
         }
       },
       "if": {
-        "properties": { "hosting": { "const": "external" } },
-        "required": ["hosting"]
+        "properties": {
+          "hosting": {
+            "const": "external"
+          }
+        },
+        "required": [
+          "hosting"
+        ]
       },
       "then": {
-        "required": ["endpoint"]
+        "required": [
+          "endpoint"
+        ]
       },
       "additionalProperties": false
     },
     "appConfig": {
       "type": "object",
       "description": "Configuration for a single application (backend or frontend).",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
           "description": "App type: backend, frontend, or docker (runs a prebuilt image).",
-          "enum": ["backend", "frontend", "docker"]
+          "enum": [
+            "backend",
+            "frontend",
+            "docker"
+          ]
         },
         "scope": {
           "type": "string",
           "description": "Where this app runs. 'all' (default): started by `spky dev` AND deployed to cloud. 'devOnly': local-only process started by `spky dev`, never deployed (no spec/method/deploy required). 'cloudOnly': deployed but skipped by `spky dev`.",
-          "enum": ["all", "devOnly", "cloudOnly"],
+          "enum": [
+            "all",
+            "devOnly",
+            "cloudOnly"
+          ],
           "default": "all"
         },
         "image": {
           "type": "string",
           "description": "Prebuilt docker image to run (required for type: docker), e.g. 'livekit/livekit-server:latest'.",
-          "examples": ["livekit/livekit-server:latest"]
+          "examples": [
+            "livekit/livekit-server:latest"
+          ]
         },
         "ports": {
           "type": "array",
-          "description": "Published ports for a type: docker app. Each entry is a bare port (7880 → 7880:7880), a host:container map ('3000:8080'), optionally with a protocol ('7882/udp').",
-          "items": { "type": ["string", "integer"] }
+          "description": "Published ports for a type: docker app. Each entry is a bare port (7880 \u2192 7880:7880), a host:container map ('3000:8080'), optionally with a protocol ('7882/udp').",
+          "items": {
+            "type": [
+              "string",
+              "integer"
+            ]
+          }
         },
         "args": {
           "type": "array",
           "description": "Args appended after the image (the container command) for a type: docker app, e.g. ['--dev', '--bind', '0.0.0.0'] or ['go', 'run', '.'].",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "volumes": {
           "type": "array",
           "description": "Bind/volume mounts for a type: docker app (docker run -v), e.g. ['/var/run/docker.sock:/var/run/docker.sock', '${PROJECT_DIR}/../..:/src', 'cache:/go']. ${PROJECT_DIR} (the absolute dir of sp00ky.yml) is expanded in the host portion (and in env values).",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "workdir": {
           "type": "string",
@@ -277,7 +342,9 @@
         "dependsOn": {
           "type": "array",
           "description": "Names of other type: docker apps that must be ready before this one starts. `spky dev` starts apps in dependency order; an unknown name, a self-dependency, or a cycle is rejected at config load.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "healthcheck": {
           "type": "string",
@@ -286,7 +353,10 @@
         "hosting": {
           "type": "string",
           "description": "Whether this backend is deployed to Sp00ky Cloud or self-hosted.",
-          "enum": ["cloud", "external"],
+          "enum": [
+            "cloud",
+            "external"
+          ],
           "default": "cloud"
         },
         "spec": {
@@ -296,7 +366,9 @@
         "baseUrl": {
           "type": "string",
           "description": "Base URL of the backend service (required when hosting is \"external\").",
-          "examples": ["https://api.example.com"]
+          "examples": [
+            "https://api.example.com"
+          ]
         },
         "auth": {
           "$ref": "#/$defs/authConfig"
@@ -317,19 +389,34 @@
       "allOf": [
         {
           "if": {
-            "properties": { "type": { "const": "backend" } }
+            "properties": {
+              "type": {
+                "const": "backend"
+              }
+            }
           },
           "then": {
-            "required": ["spec", "method"]
+            "required": [
+              "spec",
+              "method"
+            ]
           }
         },
         {
           "if": {
-            "properties": { "hosting": { "const": "external" } },
-            "required": ["hosting"]
+            "properties": {
+              "hosting": {
+                "const": "external"
+              }
+            },
+            "required": [
+              "hosting"
+            ]
           },
           "then": {
-            "required": ["baseUrl"]
+            "required": [
+              "baseUrl"
+            ]
           }
         }
       ],
@@ -338,12 +425,16 @@
     "authConfig": {
       "type": "object",
       "description": "Authentication configuration for a backend service.",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Authentication type.",
-          "enum": ["token"]
+          "enum": [
+            "token"
+          ]
         },
         "token": {
           "type": "string",
@@ -355,12 +446,17 @@
     "backendMethod": {
       "type": "object",
       "description": "Defines how the backend is triggered.",
-      "required": ["type", "schema"],
+      "required": [
+        "type",
+        "schema"
+      ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Method type for calling the backend.",
-          "enum": ["outbox"]
+          "enum": [
+            "outbox"
+          ]
         },
         "table": {
           "type": "string",
@@ -383,11 +479,19 @@
         {
           "type": "object",
           "description": "Typed dev server configuration.",
-          "required": ["type"],
+          "required": [
+            "type"
+          ],
           "oneOf": [
-            { "$ref": "#/$defs/devConfigNpm" },
-            { "$ref": "#/$defs/devConfigDocker" },
-            { "$ref": "#/$defs/devConfigUv" }
+            {
+              "$ref": "#/$defs/devConfigNpm"
+            },
+            {
+              "$ref": "#/$defs/devConfigDocker"
+            },
+            {
+              "$ref": "#/$defs/devConfigUv"
+            }
           ]
         }
       ]
@@ -395,9 +499,15 @@
     "devConfigNpm": {
       "type": "object",
       "description": "Run an npm/pnpm script as the dev server.",
-      "required": ["type", "script"],
+      "required": [
+        "type",
+        "script"
+      ],
       "properties": {
-        "type": { "type": "string", "const": "npm" },
+        "type": {
+          "type": "string",
+          "const": "npm"
+        },
         "script": {
           "type": "string",
           "description": "npm script name to run (e.g. \"dev\")."
@@ -412,9 +522,15 @@
     "devConfigDocker": {
       "type": "object",
       "description": "Build and run a Dockerfile as the dev server.",
-      "required": ["type", "file"],
+      "required": [
+        "type",
+        "file"
+      ],
       "properties": {
-        "type": { "type": "string", "const": "docker" },
+        "type": {
+          "type": "string",
+          "const": "docker"
+        },
         "file": {
           "type": "string",
           "description": "Dockerfile to build."
@@ -426,6 +542,17 @@
         "port": {
           "type": "string",
           "description": "Port mapping (e.g. \"3000:3000\")."
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional port mappings (host:container) for apps that listen on more than one port, e.g. REST + gRPC. Merged with `port`."
+        },
+        "platform": {
+          "type": "string",
+          "description": "docker --platform for build + run, e.g. \"linux/arm64\" to build/run natively instead of emulating the deploy arch."
         }
       },
       "additionalProperties": false
@@ -433,9 +560,15 @@
     "devConfigUv": {
       "type": "object",
       "description": "Run a Python script via uv as the dev server.",
-      "required": ["type", "script"],
+      "required": [
+        "type",
+        "script"
+      ],
       "properties": {
-        "type": { "type": "string", "const": "uv" },
+        "type": {
+          "type": "string",
+          "const": "uv"
+        },
         "script": {
           "type": "string",
           "description": "Python script to run via `uv run` (e.g. \"server.py\")."
@@ -468,7 +601,9 @@
         "ports": {
           "type": "array",
           "description": "Additional published ports (e.g. ['3670:3670', '7882:7882/udp']). Used for apps requiring multiple ports. The primary 'port' is still required for Traefik routing.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "expose": {
           "type": "boolean",
@@ -498,7 +633,7 @@
       "additionalProperties": false
     },
     "envConfig": {
-      "description": "Environment variable configuration. Supports multiple forms:\n- \"vault\" — fetch all vars from encrypted vault\n- { vault: [KEY1, KEY2] } — fetch only whitelisted vars from vault\n- \"path/to/file\" — load from dotenv file\n- { KEY: \"val\" } — inline key-value map\n- { dev: <source>, cloud: <source> } — per-environment split\n- [<source>, ...] — array of sources, merged in order (later overrides earlier)",
+      "description": "Environment variable configuration. Supports multiple forms:\n- \"vault\" \u2014 fetch all vars from encrypted vault\n- { vault: [KEY1, KEY2] } \u2014 fetch only whitelisted vars from vault\n- \"path/to/file\" \u2014 load from dotenv file\n- { KEY: \"val\" } \u2014 inline key-value map\n- { dev: <source>, cloud: <source> } \u2014 per-environment split\n- [<source>, ...] \u2014 array of sources, merged in order (later overrides earlier)",
       "oneOf": [
         {
           "type": "string",
@@ -558,12 +693,18 @@
     "clientTypeConfig": {
       "type": "object",
       "description": "Generated client type configuration.",
-      "required": ["format", "output"],
+      "required": [
+        "format",
+        "output"
+      ],
       "properties": {
         "format": {
           "type": "string",
           "description": "Output format. 'typescript' uses the built-in generator; 'dart' runs spooky_core's rich generator (`dart run spooky_core:spooky_gen`) from `workdir`.",
-          "enum": ["typescript", "dart"]
+          "enum": [
+            "typescript",
+            "dart"
+          ]
         },
         "output": {
           "type": "string",
@@ -571,7 +712,7 @@
         },
         "workdir": {
           "type": "string",
-          "description": "For format: dart — optional override for the directory (relative to sp00ky.yml) to run the Dart generator from. Must be a Dart package that depends on spooky_core. By default it's auto-derived from `output`'s nearest ancestor pubspec.yaml. Ignored for TypeScript."
+          "description": "For format: dart \u2014 optional override for the directory (relative to sp00ky.yml) to run the Dart generator from. Must be a Dart package that depends on spooky_core. By default it's auto-derived from `output`'s nearest ancestor pubspec.yaml. Ignored for TypeScript."
         }
       },
       "additionalProperties": false
@@ -628,7 +769,9 @@
         "bucketUrl": {
           "type": "string",
           "description": "External S3-compatible bucket URL. If set, MinIO is skipped.",
-          "examples": ["https://api.example.com"]
+          "examples": [
+            "https://api.example.com"
+          ]
         },
         "credentialsEnvFile": {
           "type": "string",

--- a/apps/landing-page/src/pages/docs/authentication.mdx
+++ b/apps/landing-page/src/pages/docs/authentication.mdx
@@ -42,6 +42,21 @@ username: 'new_user',
 password: 'secure_password'
 });`;
 
+export const codePerm = `-- A live stream's presence row is readable by its owner, by anyone when the
+-- broadcast is public, and by collaborators the owner shared it with as admin.
+DEFINE TABLE stream_presence SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE
+      -- 1. the owner reads their own rows (flat comparison)
+      ( $access = "account" AND owner = $auth.id )
+      -- 2. anyone reads a publicly shared broadcast's rows (relational subquery)
+      OR owner IN (SELECT VALUE owner FROM broadcast WHERE share_visibility = 'public')
+      -- 3. an admin collaborator reads them (subquery over a record link)
+      OR ( $access = "account" AND owner IN (
+             SELECT VALUE broadcast.owner FROM broadcast_share
+             WHERE user = $auth.id AND role = 'admin') )
+    FOR create, update, delete WHERE false;`;
+
 export const code2 = `await db.auth.signOut();`;
 
 export const code1 = `import { createSignal, onCleanup } from 'solid-js';
@@ -128,6 +143,50 @@ shared anonymous bucket), so:
 Nothing to configure — this is the default behavior with
 `database.store: 'indexeddb'`. Details in
 [Architecture → Per-User Local Buckets](/docs/architecture#per-user-local-buckets).
+
+## Row-Level Permissions in Live Queries
+
+A table's `PERMISSIONS FOR select` clause is more than a server-side gate: Sp00ky
+compiles it into a row filter that is injected into **every live query** on that
+table, enforced identically by the server SSP and the in-browser WASM processor.
+A client never registers a query that could return rows its permission forbids,
+and the filter is re-evaluated incrementally as data changes.
+
+### Supported expressions
+
+- Field comparisons: `=`, `!=`, `<`, `<=`, `>`, `>=`, and string prefix matches.
+- Boolean composition with `AND` and `OR`.
+- The `$auth` and `$access` parameters (e.g. `owner = $auth.id`,
+  `$access = "account"`).
+- **Relational membership** via `IN (SELECT VALUE <field> FROM <table> WHERE …)`.
+  The inner `WHERE` may itself reference `$auth`. This lowers to an incremental
+  semi-join, so when the referenced table changes (a broadcast is made public, a
+  share is revoked) the affected live queries update on their own — no refetch.
+- A subquery that projects a **record-link field** (`SELECT VALUE link.field`)
+  resolves the link with a nested join, so two-hop rules like "rows whose owner
+  is the owner of a broadcast shared with me" work.
+
+<CodeBlock
+  code={codePerm}
+  lang="sql"
+/>
+
+<Note>
+  All three branches above are enforced on the client too. A viewer only ever
+  syncs the presence rows they are actually allowed to see; making a broadcast
+  private retracts its rows from every unrelated viewer's live query.
+</Note>
+
+### Not supported
+
+<Warning title="Unsupported permission constructs">
+  `EXISTS (SELECT …)` and `$parent` correlation inside a permission clause are
+  not representable in the live-query engine and are rejected at registration
+  time with the offending table named. Rewrite `EXISTS` as an `IN (SELECT VALUE …)`
+  membership check. A table whose permission fails to compile is never synced
+  (fail-closed), so a client can never receive rows an unrepresentable rule was
+  meant to guard.
+</Warning>
 
 ## Third-Party Providers
 

--- a/apps/scheduler/Cargo.toml
+++ b/apps/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 
 [dependencies]

--- a/apps/scheduler/Cargo.toml
+++ b/apps/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 
 [dependencies]

--- a/apps/scheduler/package.json
+++ b/apps/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target scheduler -t mono424/spooky-scheduler:dev -f ../../Dockerfile ../..",

--- a/apps/scheduler/package.json
+++ b/apps/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target scheduler -t mono424/spooky-scheduler:dev -f ../../Dockerfile ../..",

--- a/apps/ssp/Cargo.toml
+++ b/apps/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2024"
 
 [dependencies]

--- a/apps/ssp/Cargo.toml
+++ b/apps/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2024"
 
 [dependencies]

--- a/apps/ssp/package.json
+++ b/apps/ssp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssp",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target ssp -t mono424/spooky-ssp:dev -f ../../Dockerfile ../..",

--- a/apps/ssp/package.json
+++ b/apps/ssp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssp",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target ssp -t mono424/spooky-ssp:dev -f ../../Dockerfile ../..",

--- a/example/api/package.json
+++ b/example/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-api",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:example": "pnpm dev",

--- a/example/api/package.json
+++ b/example/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-api",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:example": "pnpm dev",

--- a/example/app-solid/package.json
+++ b/example/app-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/app-solid",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Solid.js Thread Application with Authentication",
   "type": "module",
   "scripts": {

--- a/example/app-solid/package.json
+++ b/example/app-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/app-solid",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Solid.js Thread Application with Authentication",
   "type": "module",
   "scripts": {

--- a/example/e2e/package.json
+++ b/example/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/e2e",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "scripts": {
     "test": "playwright test",

--- a/example/e2e/package.json
+++ b/example/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/e2e",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "scripts": {
     "test": "playwright test",

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/project",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "description": "Example Sp00ky project",
   "scripts": {

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/project",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "description": "Example Sp00ky project",
   "scripts": {

--- a/example/schema/package.json
+++ b/example/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/schema",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Database schema and types for SurrealDB",
   "keywords": [
     "database",

--- a/example/schema/package.json
+++ b/example/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/schema",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Database schema and types for SurrealDB",
   "keywords": [
     "database",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp00ky",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "description": "Sp00ky monorepo",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp00ky",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "description": "Sp00ky monorepo",
   "scripts": {

--- a/packages/client-solid/package.json
+++ b/packages/client-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/client-solid",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "type": "module",
   "description": "SurrealDB client with local and remote database support for browser applications",
   "main": "./dist/index.cjs",

--- a/packages/client-solid/package.json
+++ b/packages/client-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/client-solid",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "type": "module",
   "description": "SurrealDB client with local and remote database support for browser applications",
   "main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/core",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/core",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/job-runner/Cargo.toml
+++ b/packages/job-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job-runner"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 
 [dependencies]

--- a/packages/job-runner/Cargo.toml
+++ b/packages/job-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job-runner"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 
 [dependencies]

--- a/packages/query-builder/package.json
+++ b/packages/query-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/query-builder",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "description": "Type-safe query builder for SurrealDB with relationship support",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/query-builder/package.json
+++ b/packages/query-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/query-builder",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "description": "Type-safe query builder for SurrealDB with relationship support",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/spooky_core/pubspec.yaml
+++ b/packages/spooky_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spooky_core
 description: Pure-Dart core for Spooky local-first sync (framework-agnostic).
-version: 0.0.1-canary.105
+version: 0.0.1-canary.106
 publish_to: none
 
 environment:

--- a/packages/spooky_core/pubspec.yaml
+++ b/packages/spooky_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spooky_core
 description: Pure-Dart core for Spooky local-first sync (framework-agnostic).
-version: 0.0.1-canary.106
+version: 0.0.1-canary.107
 publish_to: none
 
 environment:

--- a/packages/ssp-ffi/Cargo.toml
+++ b/packages/ssp-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-ffi"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 description = "C ABI (Dart FFI) bindings for ssp"
 license = "MIT"

--- a/packages/ssp-ffi/Cargo.toml
+++ b/packages/ssp-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-ffi"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 description = "C ABI (Dart FFI) bindings for ssp"
 license = "MIT"

--- a/packages/ssp-protocol/Cargo.toml
+++ b/packages/ssp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-protocol"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 
 [dependencies]

--- a/packages/ssp-protocol/Cargo.toml
+++ b/packages/ssp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-protocol"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 
 [dependencies]

--- a/packages/ssp-wasm/Cargo.toml
+++ b/packages/ssp-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-wasm"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 description = "WASM bindings for ssp"
 license = "MIT"

--- a/packages/ssp-wasm/Cargo.toml
+++ b/packages/ssp-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-wasm"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 description = "WASM bindings for ssp"
 license = "MIT"

--- a/packages/ssp-wasm/package.json
+++ b/packages/ssp-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/ssp-wasm",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "main": "pkg/ssp_wasm.js",
   "types": "pkg/ssp_wasm.d.ts",
   "files": [

--- a/packages/ssp-wasm/package.json
+++ b/packages/ssp-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/ssp-wasm",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "main": "pkg/ssp_wasm.js",
   "types": "pkg/ssp_wasm.d.ts",
   "files": [

--- a/packages/ssp/Cargo.toml
+++ b/packages/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.0.1-canary.105"
+version = "0.0.1-canary.106"
 edition = "2021"
 
 [lib]

--- a/packages/ssp/Cargo.toml
+++ b/packages/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.0.1-canary.106"
+version = "0.0.1-canary.107"
 edition = "2021"
 
 [lib]

--- a/packages/ssp/src/converter.rs
+++ b/packages/ssp/src/converter.rs
@@ -185,9 +185,46 @@ fn parse_leaf_predicate(input: &str) -> IResult<&str, Value> {
 
 fn parse_term(input: &str) -> IResult<&str, Value> {
     alt((
+        // `<path> IN (SELECT VALUE <col|link.field> FROM <table> [WHERE ...])`
+        // must be tried before the parenthesised-expression and leaf branches:
+        // it starts with an identifier like the leaf, but the `IN (SELECT ...`
+        // tail is what distinguishes it. On any mismatch it backtracks cleanly.
+        parse_in_subquery_leaf,
         delimited(ws(char('(')), parse_or_expression, ws(char(')'))),
         parse_leaf_predicate,
     ))(input)
+}
+
+/// Parse `<path> IN ( SELECT VALUE <proj> FROM <table> [WHERE <pred>] )`.
+///
+/// Emits an `in_subquery` marker node (not a `Predicate` — it lowers to a
+/// `SemiJoin`, an operator, in [`lower_where_to_plan`]). `proj` is either a bare
+/// column (single-hop: `owner`) or a `<link>.<field>` record-link traversal
+/// (two-hop: `broadcast.owner`), handled in [`semijoin_for_subquery`].
+fn parse_in_subquery_leaf(input: &str) -> IResult<&str, Value> {
+    let (input, left) = ws(parse_identifier)(input)?;
+    // SurrealDB canonicalises `IN` to `INSIDE` in stored permission text, so
+    // accept both. INSIDE is tried first: it is the longer keyword, and matching
+    // `IN` first would leave a dangling `SIDE` and fail the `(`.
+    let (input, _) = ws(alt((tag_no_case("INSIDE"), tag_no_case("IN"))))(input)?;
+    let (input, _) = ws(char('('))(input)?;
+    let (input, _) = ws(tag_no_case("SELECT"))(input)?;
+    let (input, _) = ws(tag_no_case("VALUE"))(input)?;
+    let (input, proj) = ws(parse_identifier)(input)?;
+    let (input, _) = ws(tag_no_case("FROM"))(input)?;
+    let (input, table) = ws(parse_identifier)(input)?;
+    let (input, where_logic) = opt(ws(parse_where_logic))(input)?;
+    let (input, _) = ws(char(')'))(input)?;
+    Ok((
+        input,
+        json!({
+            "type": "in_subquery",
+            "left": left,
+            "proj": proj,
+            "table": table,
+            "where": where_logic,
+        }),
+    ))
 }
 
 fn parse_and_expression(input: &str) -> IResult<&str, Value> {
@@ -349,7 +386,13 @@ fn parse_full_query(input: &str) -> IResult<&str, Value> {
     let mut current_op = json!({ "op": "scan", "table": table });
 
     if let Some(logic) = where_logic {
-        current_op = wrap_conditions(current_op, logic);
+        if where_contains_subquery(&logic) {
+            // A WHERE with an `IN (subquery)` term can't be a flat Filter — it
+            // lowers to SemiJoin / Union / Distinct operators.
+            current_op = lower_where_to_plan(&current_op, &logic);
+        } else {
+            current_op = wrap_conditions(current_op, logic);
+        }
     }
 
     // Projections
@@ -376,6 +419,118 @@ fn parse_full_query(input: &str) -> IResult<&str, Value> {
     }
 
     Ok((input, current_op))
+}
+
+/// True if `expr` contains an `in_subquery` marker anywhere in its AND/OR tree.
+fn where_contains_subquery(expr: &Value) -> bool {
+    match expr.get("type").and_then(|t| t.as_str()) {
+        Some("in_subquery") => true,
+        Some("and") | Some("or") => expr
+            .get("predicates")
+            .and_then(|p| p.as_array())
+            .map(|list| list.iter().any(where_contains_subquery))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Lower a WHERE expression that contains `IN (subquery)` term(s) into an
+/// operator plan (JSON) over `scan` that yields the outer table's allowed keys.
+///
+/// - `OR`  → `Distinct(Union(branch_plans...))` (Union merges Z-sets over the
+///   same outer scan; Distinct clamps duplicate keys to weight 1).
+/// - `AND` → apply the pure-predicate conjuncts as one `Filter` on the outer
+///   scan, then thread each `IN (subquery)` conjunct as a `SemiJoin` on top.
+/// - a bare `in_subquery` → a single `SemiJoin` (see [`semijoin_for_subquery`]).
+/// - anything else (a plain predicate) → `Filter(scan, predicate)`.
+fn lower_where_to_plan(scan: &Value, expr: &Value) -> Value {
+    match expr.get("type").and_then(|t| t.as_str()) {
+        Some("or") => {
+            let branches = expr
+                .get("predicates")
+                .and_then(|p| p.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let mut plans = branches.iter().map(|b| lower_where_to_plan(scan, b));
+            let first = plans.next().unwrap_or_else(|| scan.clone());
+            let unioned = plans.fold(first, |acc, p| {
+                json!({ "op": "union", "left": acc, "right": p })
+            });
+            json!({ "op": "distinct", "input": unioned })
+        }
+        Some("and") => {
+            let list = expr
+                .get("predicates")
+                .and_then(|p| p.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let (subs, preds): (Vec<Value>, Vec<Value>) =
+                list.into_iter().partition(where_contains_subquery);
+            let mut base = scan.clone();
+            if !preds.is_empty() {
+                let pred = if preds.len() == 1 {
+                    preds[0].clone()
+                } else {
+                    json!({ "type": "and", "predicates": preds })
+                };
+                base = json!({ "op": "filter", "predicate": pred, "input": base });
+            }
+            for sub in subs {
+                base = semijoin_for_subquery(&base, &sub);
+            }
+            base
+        }
+        Some("in_subquery") => semijoin_for_subquery(scan, expr),
+        _ => json!({ "op": "filter", "predicate": expr.clone(), "input": scan.clone() }),
+    }
+}
+
+/// Build the `SemiJoin` plan for one `IN (subquery)` term whose left is `base`.
+///
+/// Single-hop (`proj = "owner"`):
+///   `SemiJoin(base, Filter(Scan{table}, where), on: <left> = owner)`
+///
+/// Two-hop (`proj = "broadcast.owner"`): the projected value lives on the record
+/// linked from `table.<link>`, which the runtime can't dereference across rows.
+/// So we first resolve the linked rows with an inner semi-join, then match on
+/// the target field:
+///   inner  = SemiJoin(Scan{link}, Filter(Scan{table}, where), on: id = <link>)
+///   result = SemiJoin(base, inner, on: <left> = <field>)
+/// The link's target table is taken to be the link field's name (the schema
+/// convention here: `broadcast_share.broadcast` is `record<broadcast>`).
+fn semijoin_for_subquery(base: &Value, sub: &Value) -> Value {
+    let left = sub.get("left").and_then(|v| v.as_str()).unwrap_or("id");
+    let proj = sub.get("proj").and_then(|v| v.as_str()).unwrap_or("id");
+    let table = sub.get("table").and_then(|v| v.as_str()).unwrap_or("");
+    let where_logic = sub.get("where").filter(|w| !w.is_null());
+
+    let mut inner_scan = json!({ "op": "scan", "table": table });
+    if let Some(w) = where_logic {
+        inner_scan = json!({ "op": "filter", "predicate": w.clone(), "input": inner_scan });
+    }
+
+    match proj.split_once('.') {
+        Some((link, field)) => {
+            let inner = json!({
+                "op": "semijoin",
+                "left": { "op": "scan", "table": link },
+                "right": inner_scan,
+                "on": { "left_field": "id", "right_field": link },
+            });
+            json!({
+                "op": "semijoin",
+                "left": base.clone(),
+                "right": inner,
+                "on": { "left_field": left, "right_field": field },
+            })
+        }
+        None => json!({
+            "op": "semijoin",
+            "left": base.clone(),
+            "right": inner_scan,
+            "on": { "left_field": left, "right_field": proj },
+        }),
+    }
 }
 
 fn wrap_conditions(input_op: Value, predicate: Value) -> Value {

--- a/packages/ssp/src/permission_inject.rs
+++ b/packages/ssp/src/permission_inject.rs
@@ -20,8 +20,21 @@ use anyhow::{anyhow, Result};
 use serde_json::Value;
 
 use crate::converter;
-use crate::operator::plan::{OperatorPlan, Projection};
+use crate::operator::plan::{JoinCondition, OperatorPlan, Projection};
 use crate::operator::predicate::Predicate;
+use crate::types::Path;
+
+/// The result of lowering a table's SELECT permission. A permission that is a
+/// flat boolean over the scanned table is a [`Predicate`] (AND-folded into the
+/// existing Filter). One that references another table via `IN (subquery)`
+/// lowers to a whole [`OperatorPlan`] over `Scan{table}` (SemiJoin / Union /
+/// Distinct) that yields the allowed keys; it's composed with the view by a
+/// `SemiJoin(view, perm, on: id = id)` — i.e. keep view rows whose id the
+/// permission also admits.
+enum PermInjection {
+    Pred(Predicate),
+    Plan(OperatorPlan),
+}
 
 /// Walk `plan` and inject each scanned table's permission predicate. Errors
 /// abort registration; partial injection is never visible.
@@ -41,23 +54,36 @@ fn inject_node(
     match plan {
         OperatorPlan::Scan { table } => {
             let table_name = table.clone();
-            let Some(injected) = build_predicate(&table_name, perms, params)? else {
+            let Some(injected) = build_injection(&table_name, perms, params)? else {
                 return Ok(());
             };
             let scan = OperatorPlan::Scan { table: table_name };
-            *plan = OperatorPlan::Filter {
-                input: Box::new(scan),
-                predicate: injected,
+            *plan = match injected {
+                PermInjection::Pred(predicate) => OperatorPlan::Filter {
+                    input: Box::new(scan),
+                    predicate,
+                },
+                PermInjection::Plan(perm) => intersect_with_permission(scan, perm),
             };
         }
         OperatorPlan::Filter { input, predicate } => {
             if let OperatorPlan::Scan { table } = input.as_ref() {
                 let table_name = table.clone();
-                let Some(injected) = build_predicate(&table_name, perms, params)? else {
+                let Some(injected) = build_injection(&table_name, perms, params)? else {
                     return Ok(());
                 };
-                let original = std::mem::replace(predicate, Predicate::True);
-                *predicate = and_predicates(original, injected);
+                match injected {
+                    PermInjection::Pred(p) => {
+                        let original = std::mem::replace(predicate, Predicate::True);
+                        *predicate = and_predicates(original, p);
+                    }
+                    PermInjection::Plan(perm) => {
+                        // Keep the view's own Filter{Scan} as the semi-join left,
+                        // so both the view predicate AND the permission apply.
+                        let view = std::mem::replace(plan, OperatorPlan::Scan { table: table_name });
+                        *plan = intersect_with_permission(view, perm);
+                    }
+                }
                 return Ok(());
             }
             inject_node(input, perms, params)?;
@@ -89,11 +115,24 @@ fn inject_node(
 /// needed) or for `_00_*` meta tables that the SSP accesses directly. Returns
 /// `Err` for default-deny, unsupported constructs, missing `$auth`, or
 /// converter parse failures.
-fn build_predicate(
+/// Compose a permission subplan with the view: keep view rows whose `id` the
+/// permission also admits.
+fn intersect_with_permission(view: OperatorPlan, perm: OperatorPlan) -> OperatorPlan {
+    OperatorPlan::SemiJoin {
+        left: Box::new(view),
+        right: Box::new(perm),
+        on: JoinCondition {
+            left_field: Path::new("id"),
+            right_field: Path::new("id"),
+        },
+    }
+}
+
+fn build_injection(
     table: &str,
     perms: &HashMap<String, String>,
     params: Option<&Value>,
-) -> Result<Option<Predicate>> {
+) -> Result<Option<PermInjection>> {
     let raw = match perms.get(table) {
         Some(t) => t.trim(),
         None => {
@@ -134,12 +173,17 @@ fn build_predicate(
     })?;
 
     match parsed {
-        OperatorPlan::Filter { input, predicate } => match *input {
-            OperatorPlan::Scan { .. } => Ok(Some(predicate)),
-            _ => Err(anyhow!(
-                "permission for `{table}` produced a non-flat plan (likely identifier-vs-identifier comparison)"
-            )),
-        },
+        OperatorPlan::Filter { input, predicate } if matches!(*input, OperatorPlan::Scan { .. }) => {
+            Ok(Some(PermInjection::Pred(predicate)))
+        }
+        // An `IN (subquery)` permission lowers to a SemiJoin / Union / Distinct
+        // subplan over `Scan{table}` — compose it whole (see PermInjection).
+        plan @ (OperatorPlan::SemiJoin { .. }
+        | OperatorPlan::Union { .. }
+        | OperatorPlan::Distinct { .. }) => Ok(Some(PermInjection::Plan(plan))),
+        OperatorPlan::Filter { .. } => Err(anyhow!(
+            "permission for `{table}` produced a non-flat plan (likely identifier-vs-identifier comparison)"
+        )),
         _ => Err(anyhow!(
             "permission for `{table}` produced a non-filter plan (likely a join or subquery)"
         )),
@@ -158,12 +202,10 @@ fn params_have_auth(params: Option<&Value>) -> bool {
 /// because SurrealDB doesn't care about keyword case.
 fn unsupported_construct(raw: &str) -> Option<&'static str> {
     let lower = raw.to_lowercase();
-    const NEEDLES: &[&str] = &[
-        "in (select",
-        "exists (select",
-        "(select value",
-        "$parent",
-    ];
+    // `IN (SELECT VALUE ...)` is now supported (lowered to a SemiJoin by the
+    // converter), so it is no longer denylisted. EXISTS-subqueries and $parent
+    // correlation are still unsupported.
+    const NEEDLES: &[&str] = &["exists (select", "$parent"];
     for needle in NEEDLES {
         if lower.contains(needle) {
             return Some(needle);
@@ -263,17 +305,136 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_subquery_errors() {
+    fn exists_subquery_still_unsupported() {
+        let mut plan = OperatorPlan::Scan {
+            table: "thread".into(),
+        };
+        let perms = perms_with(&[("thread", "EXISTS (SELECT VALUE in FROM collaborates_on)")]);
+        let params = json!({"auth": {"id": "user:a"}});
+        let err = inject_permissions(&mut plan, &perms, Some(&params)).unwrap_err();
+        assert!(err.to_string().contains("unsupported construct"));
+    }
+
+    #[test]
+    fn single_hop_in_subquery_injects_semijoin() {
+        // `owner IN (SELECT VALUE owner FROM broadcast WHERE share_visibility = 'public')`
+        // over a plain scan → SemiJoin(Scan{thread}, Filter(Scan{broadcast}, ...)).
         let mut plan = OperatorPlan::Scan {
             table: "thread".into(),
         };
         let perms = perms_with(&[(
             "thread",
-            "$auth.id IN (SELECT VALUE in FROM collaborates_on)",
+            "owner IN (SELECT VALUE owner FROM broadcast WHERE share_visibility = 'public')",
+        )]);
+        inject_permissions(&mut plan, &perms, None).unwrap();
+        // Root is the id=id intersection wrapper: SemiJoin(view, perm).
+        match plan {
+            OperatorPlan::SemiJoin { left, right, on } => {
+                assert!(matches!(*left, OperatorPlan::Scan { .. }), "left is the view scan");
+                assert_eq!(on.left_field.segments(), &["id".to_string()]);
+                assert_eq!(on.right_field.segments(), &["id".to_string()]);
+                // right is the permission plan: SemiJoin(Scan{thread}, Filter(Scan{broadcast})).
+                match *right {
+                    OperatorPlan::SemiJoin { right: perm_right, on: perm_on, .. } => {
+                        assert_eq!(perm_on.left_field.segments(), &["owner".to_string()]);
+                        assert_eq!(perm_on.right_field.segments(), &["owner".to_string()]);
+                        match *perm_right {
+                            OperatorPlan::Filter { input, .. } => {
+                                assert!(matches!(*input, OperatorPlan::Scan { table } if table == "broadcast"));
+                            }
+                            other => panic!("expected Filter(Scan broadcast), got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected permission SemiJoin, got {:?}", other),
+                }
+            }
+            other => panic!("expected SemiJoin at root, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn inside_canonical_form_is_supported() {
+        // SurrealDB stores `IN` as `INSIDE`; the injector must handle both.
+        let mut plan = OperatorPlan::Scan {
+            table: "thread".into(),
+        };
+        let perms = perms_with(&[(
+            "thread",
+            "owner INSIDE (SELECT VALUE owner FROM broadcast WHERE share_visibility = 'public')",
+        )]);
+        inject_permissions(&mut plan, &perms, None).unwrap();
+        assert!(matches!(plan, OperatorPlan::SemiJoin { .. }), "INSIDE lowered to SemiJoin");
+    }
+
+    #[test]
+    fn two_hop_in_subquery_injects_nested_semijoin() {
+        // `owner IN (SELECT VALUE broadcast.owner FROM broadcast_share WHERE ...)`
+        // → SemiJoin(view, SemiJoin(Scan{broadcast}, Filter(Scan{broadcast_share})))
+        let mut plan = OperatorPlan::Scan {
+            table: "stream_presence".into(),
+        };
+        let perms = perms_with(&[(
+            "stream_presence",
+            "owner IN (SELECT VALUE broadcast.owner FROM broadcast_share WHERE user = $auth.id AND role = 'admin')",
         )]);
         let params = json!({"auth": {"id": "user:a"}});
-        let err = inject_permissions(&mut plan, &perms, Some(&params)).unwrap_err();
-        assert!(err.to_string().contains("unsupported construct"));
+        inject_permissions(&mut plan, &perms, Some(&params)).unwrap();
+        // Root: id=id intersection wrapper. right = permission plan
+        // SemiJoin(Scan{stream_presence}, inner, on owner=owner), where inner
+        // resolves admin-shared broadcasts.
+        match plan {
+            OperatorPlan::SemiJoin { right, on, .. } => {
+                assert_eq!(on.left_field.segments(), &["id".to_string()]);
+                assert_eq!(on.right_field.segments(), &["id".to_string()]);
+                match *right {
+                    OperatorPlan::SemiJoin { right: perm_right, on: perm_on, .. } => {
+                        assert_eq!(perm_on.left_field.segments(), &["owner".to_string()]);
+                        assert_eq!(perm_on.right_field.segments(), &["owner".to_string()]);
+                        // inner: SemiJoin(Scan{broadcast}, Filter(Scan{broadcast_share}), on id=broadcast)
+                        match *perm_right {
+                            OperatorPlan::SemiJoin { left, on: inner_on, .. } => {
+                                assert!(matches!(*left, OperatorPlan::Scan { table } if table == "broadcast"));
+                                assert_eq!(inner_on.left_field.segments(), &["id".to_string()]);
+                                assert_eq!(inner_on.right_field.segments(), &["broadcast".to_string()]);
+                            }
+                            other => panic!("expected inner SemiJoin, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected permission SemiJoin, got {:?}", other),
+                }
+            }
+            other => panic!("expected SemiJoin at root, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn full_stream_presence_permission_injects_distinct_union() {
+        // The real schema permission: owner OR public OR admin. The whole thing
+        // must compose without error into SemiJoin(view, Distinct(Union(...))).
+        let mut plan = OperatorPlan::Filter {
+            input: Box::new(OperatorPlan::Scan {
+                table: "stream_presence".into(),
+            }),
+            predicate: Predicate::Eq {
+                field: Path::new("owner"),
+                value: json!({"$param": "owner"}),
+            },
+        };
+        let perms = perms_with(&[(
+            "stream_presence",
+            "( $access = \"account\" AND owner = $auth.id ) OR owner IN (SELECT VALUE owner FROM broadcast WHERE share_visibility = 'public') OR ( $access = \"account\" AND owner IN (SELECT VALUE broadcast.owner FROM broadcast_share WHERE user = $auth.id AND role = 'admin') )",
+        )]);
+        let params = json!({"auth": {"id": "user:a"}, "access": "account", "owner": "user:a"});
+        inject_permissions(&mut plan, &perms, Some(&params)).unwrap();
+        match plan {
+            OperatorPlan::SemiJoin { left, right, on } => {
+                assert!(matches!(*left, OperatorPlan::Filter { .. }), "view filter kept as left");
+                assert_eq!(on.left_field.segments(), &["id".to_string()]);
+                assert_eq!(on.right_field.segments(), &["id".to_string()]);
+                assert!(matches!(*right, OperatorPlan::Distinct { .. }), "permission is Distinct(Union(...))");
+            }
+            other => panic!("expected SemiJoin at root, got {:?}", other),
+        }
     }
 
     #[test]

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/tests",
-  "version": "0.0.1-canary.106",
+  "version": "0.0.1-canary.107",
   "private": true,
   "scripts": {
     "test": "jest --runInBand",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/tests",
-  "version": "0.0.1-canary.105",
+  "version": "0.0.1-canary.106",
   "private": true,
   "scripts": {
     "test": "jest --runInBand",


### PR DESCRIPTION
Ships canary.106 + canary.107.

## SSP: IN-subquery permissions (semi-join lowering)
The policy engine rejected any table whose SELECT permission used `IN (SELECT VALUE ... FROM ...)`, so a client live query on it never registered and synced nothing. This blocked whitepawn's `stream_presence` (owner OR public-broadcast OR admin-share), leaving the livestream dashboard + public viewer empty.

- converter: parse `<path> IN|INSIDE (SELECT VALUE <col|link.field> FROM <table> [WHERE ...])` -> SemiJoin; a `<link>.<field>` projection lowers to a nested SemiJoin (no runtime change); top-level OR -> Union + Distinct.
- permission_inject: subquery permission composed with the view via `SemiJoin(view, perm, on id=id)`; flat permissions still AND a predicate. Denylist now only rejects EXISTS / $parent.
- Docs section + unit tests (incl. the exact stream_presence permission). Verified end-to-end on a live SSP: owner/public/admin all enforced, private stays empty (no leak).

## CLI: native docker dev method (multi-port + platform)
The typed `dev: { type: docker }` runner only mapped one port and always built the deploy arch. Added `ports: [...]` (publish multiple listeners, e.g. WS + gRPC) and `platform` (build/run native arch). Lets a relay-style backend run through the managed docker method with proper env injection instead of a raw `docker run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)