### PR TITLE
fix(scheduler): break non-converging SSP catch-up loop + row-level diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "job-runner"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "dashmap 6.1.0",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6724,7 +6724,7 @@ dependencies = [
 
 [[package]]
 name = "sp00ky-cli"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "argon2",
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6813,7 +6813,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-ffi"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "libc",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-protocol"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "blake3",
  "serde",
@@ -6834,7 +6834,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-wasm"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/benchmark",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Performance benchmark CLI for sp00ky scheduler + SSP",
   "private": true,
   "type": "module",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp00ky-cli"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 
 [[bin]]

--- a/apps/cli/npm/cli-darwin-arm64/package.json
+++ b/apps/cli/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-arm64",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "macOS Apple Silicon binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-darwin-x64/package.json
+++ b/apps/cli/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-darwin-x64",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "macOS Intel binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-arm64/package.json
+++ b/apps/cli/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-arm64",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Linux ARM64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-linux-x64/package.json
+++ b/apps/cli/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-linux-x64",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Linux x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/npm/cli-win32-x64/package.json
+++ b/apps/cli/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli-win32-x64",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Windows x64 binary for @spooky-sync/cli",
   "license": "MIT",
   "os": [

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/cli",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Generate TypeScript/Dart types from SurrealDB schema files",
   "type": "module",
   "main": "./dist/syncgen.cjs",

--- a/apps/devtools-mcp/package.json
+++ b/apps/devtools-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools-mcp",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "MCP server for Sp00ky Sync devtools",
   "license": "MIT",
   "type": "module",

--- a/apps/devtools/package.json
+++ b/apps/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/devtools",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Chrome DevTools extension for debugging and inspecting Sp00ky state",
   "private": true,
   "type": "module",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,7 +1,7 @@
 {
   "name": "landing-page",
   "type": "module",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "scripts": {
     "dev": "astro dev",
     "dev:landingpage": "astro dev",

--- a/apps/scheduler/Cargo.toml
+++ b/apps/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 
 [dependencies]

--- a/apps/scheduler/package.json
+++ b/apps/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target scheduler -t mono424/spooky-scheduler:dev -f ../../Dockerfile ../..",

--- a/apps/scheduler/src/main.rs
+++ b/apps/scheduler/src/main.rs
@@ -55,6 +55,8 @@ async fn main() -> Result<()> {
         config: std::sync::Arc::new(config.clone()),
         status: scheduler.status.clone(),
         event_buffer: scheduler.event_buffer.clone(),
+        seq_counter: std::sync::Arc::clone(&scheduler.seq_counter),
+        reclone_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
     };
     let ssp_router = scheduler::ssp_management::create_ssp_router(ssp_mgmt_state);
 

--- a/apps/scheduler/src/router.rs
+++ b/apps/scheduler/src/router.rs
@@ -27,6 +27,12 @@ pub struct SspPool {
     /// to re-bootstrap. The next heartbeat from these SSPs returns 409 so
     /// they tear down and re-register against the current frozen snapshot.
     forced_resync: HashSet<String>,
+    /// Consecutive catch-up verification failures per SSP, reset on any pass.
+    /// A plain re-bootstrap can't fix a *deterministic* scheduler-vs-circuit
+    /// hash gap (the SSP refetches the same diverging state every cycle), so
+    /// this counter lets the catch-up path escalate — re-clone the replica,
+    /// then admit anyway — instead of looping forever. See `poll_and_replay_ssp`.
+    catchup_failures: HashMap<String, u32>,
     strategy: LoadBalanceStrategy,
     round_robin_index: usize,
     max_buffer_size: usize,
@@ -41,10 +47,26 @@ impl SspPool {
             message_buffers: HashMap::new(),
             ssp_snapshot_seqs: HashMap::new(),
             forced_resync: HashSet::new(),
+            catchup_failures: HashMap::new(),
             strategy,
             round_robin_index: 0,
             max_buffer_size,
         }
+    }
+
+    /// Record one more consecutive catch-up verification failure for this SSP
+    /// and return the new running count. Cleared by `reset_catchup_failures`
+    /// on any successful verification (or admit).
+    pub fn record_catchup_failure(&mut self, ssp_id: &str) -> u32 {
+        let entry = self.catchup_failures.entry(ssp_id.to_string()).or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Reset the consecutive catch-up failure count for this SSP (on a pass,
+    /// or once we admit it to broadcast to break the loop).
+    pub fn reset_catchup_failures(&mut self, ssp_id: &str) {
+        self.catchup_failures.remove(ssp_id);
     }
 
     /// Flag an SSP for forced re-bootstrap on its next heartbeat. Used by
@@ -219,6 +241,7 @@ impl SspPool {
         self.message_buffers.remove(ssp_id);
         self.ssp_snapshot_seqs.remove(ssp_id);
         self.forced_resync.remove(ssp_id);
+        self.catchup_failures.remove(ssp_id);
         self.ssps.remove(ssp_id)
     }
 
@@ -232,6 +255,7 @@ impl SspPool {
         self.message_buffers.clear();
         self.ssp_snapshot_seqs.clear();
         self.forced_resync.clear();
+        self.catchup_failures.clear();
         self.round_robin_index = 0;
         count
     }
@@ -338,5 +362,38 @@ impl SspPool {
         self.ssp_states
             .values()
             .any(|s| matches!(s, SspState::Bootstrapping | SspState::Replaying))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool() -> SspPool {
+        SspPool::new(LoadBalanceStrategy::RoundRobin, 100)
+    }
+
+    #[test]
+    fn catchup_failures_count_up_then_reset() {
+        let mut p = pool();
+        assert_eq!(p.record_catchup_failure("ssp-0"), 1);
+        assert_eq!(p.record_catchup_failure("ssp-0"), 2);
+        assert_eq!(p.record_catchup_failure("ssp-0"), 3);
+        // Independent per SSP.
+        assert_eq!(p.record_catchup_failure("ssp-1"), 1);
+        // Reset clears only the named SSP and restarts its streak.
+        p.reset_catchup_failures("ssp-0");
+        assert_eq!(p.record_catchup_failure("ssp-0"), 1);
+        assert_eq!(p.record_catchup_failure("ssp-1"), 2);
+    }
+
+    #[test]
+    fn remove_clears_catchup_failures() {
+        let mut p = pool();
+        p.record_catchup_failure("ssp-0");
+        p.record_catchup_failure("ssp-0");
+        p.remove("ssp-0");
+        // A re-registered SSP of the same id starts a fresh streak.
+        assert_eq!(p.record_catchup_failure("ssp-0"), 1);
     }
 }

--- a/apps/scheduler/src/ssp_management.rs
+++ b/apps/scheduler/src/ssp_management.rs
@@ -6,8 +6,9 @@ use axum::{
     Json, Router,
 };
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, error, info, warn};
 
 use crate::config::SchedulerConfig;
@@ -27,6 +28,12 @@ pub struct SspManagementState {
     pub config: Arc<SchedulerConfig>,
     pub status: Arc<RwLock<SchedulerStatus>>,
     pub event_buffer: Arc<RwLock<VecDeque<BufferedEvent>>>,
+    /// Global sequence counter — the seq the replica reflects after a re-clone.
+    pub seq_counter: Arc<AtomicU64>,
+    /// Serializes catch-up replica re-clones so two looping SSPs can't reset +
+    /// re-ingest the shared replica concurrently. A `try_lock` failure means a
+    /// re-clone is already running; the losing task just re-bootstraps instead.
+    pub reclone_lock: Arc<Mutex<()>>,
 }
 
 /// Create SSP management router
@@ -135,6 +142,8 @@ async fn handle_register(
     let event_buffer = state.event_buffer.clone();
     let scheduler_status = state.status.clone();
     let config = state.config.clone();
+    let seq_counter = state.seq_counter.clone();
+    let reclone_lock = state.reclone_lock.clone();
 
     let replica = state.replica.clone();
     tokio::spawn(async move {
@@ -148,6 +157,8 @@ async fn handle_register(
             scheduler_status,
             config,
             replica,
+            seq_counter,
+            reclone_lock,
         )
         .await
         {
@@ -253,6 +264,8 @@ async fn poll_and_replay_ssp(
     scheduler_status: Arc<RwLock<SchedulerStatus>>,
     config: Arc<SchedulerConfig>,
     replica: Arc<RwLock<Replica>>,
+    seq_counter: Arc<AtomicU64>,
+    reclone_lock: Arc<Mutex<()>>,
 ) -> Result<()> {
     let poll_interval = std::time::Duration::from_millis(config.ssp_poll_interval_ms);
     let timeout = std::time::Duration::from_secs(config.bootstrap_timeout_secs);
@@ -399,14 +412,65 @@ async fn poll_and_replay_ssp(
     // which compared the SSP's live (seq M) hashes against the frozen snapshot
     // (seq N) and so falsely flagged any table written during catch-up.
     let verified = match verify_catchup_at_m(&ssp_id, &ssp_url, &transport, &replica, &replayed).await {
-        Ok(true) => true,
+        Ok(true) => {
+            // Passed — clear the consecutive-failure streak.
+            ssp_pool.write().await.reset_catchup_failures(&ssp_id);
+            true
+        }
         Ok(false) => {
-            // Real divergence: flag for forced re-bootstrap and do NOT mark
-            // ready. The SSP (already heartbeating) gets a 409 on its next
-            // heartbeat and exits for a clean re-registration.
-            ssp_pool.write().await.mark_for_resync(&ssp_id);
-            warn!(ssp_id = %ssp_id, "Catch-up verification failed — withholding from broadcast; SSP will re-bootstrap");
-            false
+            // Real divergence. A plain re-bootstrap can't fix a *deterministic*
+            // scheduler-vs-circuit gap — the SSP refetches the same diverging
+            // state every cycle — so escalate by consecutive-failure count
+            // instead of looping forever (which leaves the whole cluster with
+            // NO ready SSP and all live queries failing).
+            let fails = ssp_pool.write().await.record_catchup_failure(&ssp_id);
+            let (reclone_after, admit_after) = catchup_breaker_thresholds();
+
+            if fails >= admit_after {
+                // Give up on the gate: admit the SSP so sync is restored. The
+                // circuit passed its own @N bootstrap self-check and every
+                // shared row is (almost certainly) semantically correct; a
+                // never-converging hash is not worth an indefinite outage. The
+                // row-level diagnostic above shows exactly what disagreed.
+                error!(
+                    ssp_id = %ssp_id,
+                    fails,
+                    "ALERT: catch-up never converged after {} attempts — admitting SSP to broadcast anyway to restore sync. Circuit may be marginally divergent from the scheduler projection (see the row-level diff above).",
+                    fails,
+                );
+                ssp_pool.write().await.reset_catchup_failures(&ssp_id);
+                true
+            } else {
+                if fails == reclone_after {
+                    // The replica itself may hold the odd representation. Do ONE
+                    // full re-clone from upstream before the next attempt so the
+                    // SSP re-bootstraps from a freshly-cloned snapshot.
+                    warn!(
+                        ssp_id = %ssp_id,
+                        fails,
+                        "Catch-up failed {} times — re-cloning replica from upstream before the next attempt",
+                        fails,
+                    );
+                    match reclone_replica_from_upstream(&config, &replica, &seq_counter, &reclone_lock).await {
+                        Ok(true) => {
+                            info!("Replica re-cloned from upstream; flagging all SSPs to re-bootstrap from the fresh snapshot");
+                            ssp_pool.write().await.mark_all_for_resync();
+                        }
+                        Ok(false) => {
+                            info!(ssp_id = %ssp_id, "Re-clone already in progress on another task; just re-bootstrapping this SSP");
+                            ssp_pool.write().await.mark_for_resync(&ssp_id);
+                        }
+                        Err(e) => {
+                            error!(ssp_id = %ssp_id, error = %e, "Replica re-clone failed; falling back to a plain re-bootstrap");
+                            ssp_pool.write().await.mark_for_resync(&ssp_id);
+                        }
+                    }
+                } else {
+                    ssp_pool.write().await.mark_for_resync(&ssp_id);
+                }
+                warn!(ssp_id = %ssp_id, fails, "Catch-up verification failed — withholding from broadcast; SSP will re-bootstrap");
+                false
+            }
         }
         Err(e) => {
             // Transient failure (e.g. /info unreachable). Favor availability —
@@ -473,7 +537,11 @@ async fn poll_and_replay_ssp(
         }
     }
 
-    info!("SSP '{}' is now fully caught up and ready", ssp_id);
+    if verified {
+        info!("SSP '{}' is now fully caught up and ready", ssp_id);
+    } else {
+        info!(ssp_id = %ssp_id, "SSP withheld from broadcast pending re-bootstrap");
+    }
     Ok(())
 }
 
@@ -609,7 +677,11 @@ async fn verify_catchup_at_m(
         }
     }
 
-    // Persistent mismatch after every attempt → a real divergence.
+    // Persistent mismatch after every attempt → a real divergence. Pull the
+    // SSP's actual circuit rows and diff them against the scheduler's projection
+    // row-by-row, so the log names the specific missing / extra / differing rows
+    // instead of the old one-sided dump (which showed the scheduler's first N
+    // rows in map order — not necessarily the diverging ones).
     for (table, sched, ssp_h) in &mismatches {
         error!(
             ssp_id = %ssp_id,
@@ -618,22 +690,57 @@ async fn verify_catchup_at_m(
             ssp = %ssp_h,
             "Catch-up hash mismatch"
         );
-        // Diagnostic: dump the canonical JSON of the scheduler's reconstructed
-        // rows (capped) so a representation gap (e.g. a `null` optional the SSP
-        // omits) is visible in the log without attaching a debugger.
-        if let Some(rows) = reference_rows.get(table) {
-            for (row_id, val) in rows.iter().take(CATCHUP_DIAG_MAX_ROWS) {
-                let canon = String::from_utf8_lossy(
-                    &ssp_protocol::snapshot_hash::canonical_json(val),
-                )
-                .into_owned();
-                error!(
-                    ssp_id = %ssp_id,
-                    table = %table,
-                    row_id = %row_id,
-                    reference_row = %canon,
-                    "Catch-up mismatch diagnostic (scheduler reconstructed row@M)"
-                );
+        let ref_rows = match reference_rows.get(table) {
+            Some(r) => r,
+            None => continue,
+        };
+        match fetch_ssp_catchup_rows(transport, ssp_url, table).await {
+            Ok(ssp_rows) => {
+                let all_ids: std::collections::BTreeSet<&String> =
+                    ref_rows.keys().chain(ssp_rows.keys()).collect();
+                let mut logged = 0usize;
+                for id in all_ids {
+                    if logged >= CATCHUP_DIAG_MAX_ROWS {
+                        warn!(ssp_id = %ssp_id, table = %table, "More diverging rows omitted (diagnostic cap reached)");
+                        break;
+                    }
+                    match (ref_rows.get(id), ssp_rows.get(id)) {
+                        (Some(r), None) => {
+                            error!(ssp_id = %ssp_id, table = %table, row_id = %id, scheduler_row = %canon_json(r), "Catch-up diff: row on scheduler, MISSING on SSP");
+                            logged += 1;
+                        }
+                        (None, Some(s)) => {
+                            error!(ssp_id = %ssp_id, table = %table, row_id = %id, ssp_row = %canon_json(s), "Catch-up diff: EXTRA row on SSP, absent on scheduler");
+                            logged += 1;
+                        }
+                        (Some(r), Some(s)) => {
+                            if ssp_protocol::snapshot_hash::record_digest(id.as_str(), r)
+                                != ssp_protocol::snapshot_hash::record_digest(id.as_str(), s)
+                            {
+                                error!(ssp_id = %ssp_id, table = %table, row_id = %id, scheduler_row = %canon_json(r), ssp_row = %canon_json(s), "Catch-up diff: row content differs");
+                                logged += 1;
+                            }
+                        }
+                        (None, None) => {}
+                    }
+                }
+                if logged == 0 {
+                    error!(ssp_id = %ssp_id, table = %table, "Catch-up hashes differ but no row-level diff found — possible canonicalization gap between scheduler and circuit");
+                }
+            }
+            Err(e) => {
+                // Couldn't reach the SSP's row dump (old build / transient) —
+                // fall back to the one-sided scheduler-projection dump.
+                warn!(ssp_id = %ssp_id, table = %table, error = %e, "Could not fetch SSP rows for row-level diff; dumping scheduler projection only");
+                for (row_id, val) in ref_rows.iter().take(CATCHUP_DIAG_MAX_ROWS) {
+                    error!(
+                        ssp_id = %ssp_id,
+                        table = %table,
+                        row_id = %row_id,
+                        reference_row = %canon_json(val),
+                        "Catch-up mismatch diagnostic (scheduler reconstructed row@M)"
+                    );
+                }
             }
         }
     }
@@ -651,8 +758,119 @@ async fn verify_catchup_at_m(
 const CATCHUP_VERIFY_ATTEMPTS: usize = 3;
 /// Delay between catch-up re-checks.
 const CATCHUP_VERIFY_RETRY_DELAY_MS: u64 = 150;
-/// Cap on per-table rows dumped in the mismatch diagnostic, to keep the log bounded.
-const CATCHUP_DIAG_MAX_ROWS: usize = 3;
+/// Cap on per-table rows dumped in the mismatch diagnostic, to keep the log
+/// bounded. Higher than the old one-sided dump because the row-level diff only
+/// logs rows that actually diverge (missing / extra / differing), so the cap is
+/// a real ceiling on divergences shown, not just the first N rows.
+const CATCHUP_DIAG_MAX_ROWS: usize = 20;
+
+/// Default consecutive catch-up failures before the breaker re-clones the
+/// replica from upstream. Override with `SPKY_CATCHUP_RECLONE_AFTER`.
+const CATCHUP_RECLONE_AFTER_DEFAULT: u32 = 3;
+/// Default consecutive catch-up failures before the breaker gives up on the
+/// gate and admits the SSP to broadcast anyway (restoring sync). Override with
+/// `SPKY_CATCHUP_ADMIT_AFTER`. Set very high to effectively disable admit; set
+/// re-clone/admit equal to skip the re-clone step.
+const CATCHUP_ADMIT_AFTER_DEFAULT: u32 = 5;
+
+/// Read the catch-up breaker thresholds `(reclone_after, admit_after)` from env,
+/// falling back to the compiled defaults. `admit_after` is floored to at least
+/// `reclone_after` so admit never precedes the re-clone attempt.
+fn catchup_breaker_thresholds() -> (u32, u32) {
+    let parse = |k: &str| {
+        std::env::var(k)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .filter(|n: &u32| *n > 0)
+    };
+    resolve_breaker_thresholds(
+        parse("SPKY_CATCHUP_RECLONE_AFTER"),
+        parse("SPKY_CATCHUP_ADMIT_AFTER"),
+    )
+}
+
+/// Pure core of [`catchup_breaker_thresholds`]: apply defaults and floor
+/// `admit` to at least `reclone` so admit never precedes the re-clone attempt.
+fn resolve_breaker_thresholds(reclone: Option<u32>, admit: Option<u32>) -> (u32, u32) {
+    let reclone = reclone.unwrap_or(CATCHUP_RECLONE_AFTER_DEFAULT);
+    let admit = admit.unwrap_or(CATCHUP_ADMIT_AFTER_DEFAULT).max(reclone);
+    (reclone, admit)
+}
+
+/// Canonical-JSON string of a value, for the mismatch diagnostic. Same encoding
+/// the hash uses, so the logged bytes are exactly what feeds the digest.
+fn canon_json(v: &serde_json::Value) -> String {
+    String::from_utf8_lossy(&ssp_protocol::snapshot_hash::canonical_json(v)).into_owned()
+}
+
+/// Fetch an SSP's circuit rows for one table (`/debug/catchup-rows/:table`),
+/// returned as `raw_id -> value`. Used by the catch-up diagnostic to diff the
+/// circuit against the scheduler's reconstructed projection.
+async fn fetch_ssp_catchup_rows(
+    transport: &Arc<HttpTransport>,
+    ssp_url: &str,
+    table: &str,
+) -> Result<std::collections::HashMap<String, serde_json::Value>> {
+    let resp = transport
+        .get_from_ssp(ssp_url, &format!("/debug/catchup-rows/{}", table))
+        .await
+        .map_err(|e| anyhow::anyhow!("GET /debug/catchup-rows failed: {}", e))?;
+    if !resp.status().is_success() {
+        anyhow::bail!("SSP /debug/catchup-rows returned HTTP {}", resp.status());
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Parse /debug/catchup-rows JSON failed: {}", e))?;
+    let rows = json
+        .get("rows")
+        .and_then(|v| v.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .unwrap_or_default();
+    Ok(rows)
+}
+
+/// Catch-up breaker step: re-clone the replica from upstream SurrealDB. Serialized
+/// by `reclone_lock` so two looping SSPs can't reset + re-ingest the shared
+/// replica at once. Returns `Ok(true)` if this call performed the re-clone,
+/// `Ok(false)` if another task already holds the lock (caller falls back to a
+/// plain re-bootstrap), `Err` on a clone failure.
+///
+/// Mirrors the bootstrap clone in `Scheduler::start`: reset the replica, clone
+/// every table from upstream, then rehash at the current global seq. Holds the
+/// replica write lock for the whole clone so in-flight bootstrap reads see a
+/// consistent snapshot (they block, then read the fresh clone).
+async fn reclone_replica_from_upstream(
+    config: &SchedulerConfig,
+    replica: &Arc<RwLock<Replica>>,
+    seq_counter: &Arc<AtomicU64>,
+    reclone_lock: &Arc<Mutex<()>>,
+) -> Result<bool> {
+    let _guard = match reclone_lock.try_lock() {
+        Ok(g) => g,
+        Err(_) => return Ok(false),
+    };
+
+    let db = crate::restore::connect_remote(&config.db)
+        .await
+        .context("reclone: connect to upstream SurrealDB failed")?;
+
+    // Snapshot the seq the clone reflects BEFORE the (slow) ingest, matching
+    // the bootstrap path — new events past this point re-arrive via replay.
+    let seq = seq_counter.load(Ordering::SeqCst);
+
+    {
+        let mut rep = replica.write().await;
+        rep.reset().await.context("reclone: replica reset failed")?;
+        rep.ingest_all(&db).await.context("reclone: ingest_all failed")?;
+        rep.set_snapshot_state(seq, None)
+            .await
+            .context("reclone: set_snapshot_state failed")?;
+    }
+
+    info!(seq, "Catch-up breaker: replica re-clone from upstream complete");
+    Ok(true)
+}
 
 /// Reconstruct a touched table's content at the catch-up cut from its rows@N
 /// (`seed`) plus the replayed `events`, then XOR-hash it. Events are applied by
@@ -714,6 +932,21 @@ mod catchup_tests {
             data,
             version: 0,
         }
+    }
+
+    #[test]
+    fn breaker_thresholds_default_and_floor() {
+        // Defaults when unset.
+        assert_eq!(
+            resolve_breaker_thresholds(None, None),
+            (CATCHUP_RECLONE_AFTER_DEFAULT, CATCHUP_ADMIT_AFTER_DEFAULT)
+        );
+        // Explicit values pass through when admit >= reclone.
+        assert_eq!(resolve_breaker_thresholds(Some(2), Some(6)), (2, 6));
+        // admit is floored to reclone so admit never precedes the re-clone.
+        assert_eq!(resolve_breaker_thresholds(Some(4), Some(1)), (4, 4));
+        // Setting them equal disables the re-clone step (admit on the same count).
+        assert_eq!(resolve_breaker_thresholds(Some(3), Some(3)), (3, 3));
     }
 
     #[test]

--- a/apps/scheduler/tests/integration.rs
+++ b/apps/scheduler/tests/integration.rs
@@ -133,6 +133,8 @@ impl TestHarness {
             config: Arc::clone(&self.config),
             status: Arc::clone(&self.status),
             event_buffer: Arc::clone(&self.event_buffer),
+            seq_counter: Arc::clone(&self.seq_counter),
+            reclone_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
         ssp_management::create_ssp_router(state)
     }

--- a/apps/ssp/Cargo.toml
+++ b/apps/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2024"
 
 [dependencies]

--- a/apps/ssp/package.json
+++ b/apps/ssp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssp",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "scripts": {
     "build": "docker buildx build --target ssp -t mono424/spooky-ssp:dev -f ../../Dockerfile ../..",

--- a/apps/ssp/src/lib.rs
+++ b/apps/ssp/src/lib.rs
@@ -435,6 +435,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/log", post(log_handler))
         .route("/debug/view/:view_id", get(debug_view_handler))
         .route("/debug/deps", get(debug_deps_handler))
+        .route("/debug/catchup-rows/:table", get(debug_catchup_rows_handler))
         .route("/view/register", post(register_view_handler))
         .route("/view/unregister", post(unregister_view_handler))
         .route("/crdt/apply", post(crdt_apply_handler))
@@ -3184,6 +3185,23 @@ async fn debug_view_handler(
     } else {
         Json(json!({ "error": "View not found" }))
     }
+}
+
+/// Dump one table's circuit rows as `{ raw_id: json }`. The scheduler fetches
+/// this on a persistent catch-up hash mismatch to diff its reconstructed
+/// projection against the circuit row-by-row (see the scheduler's
+/// `verify_catchup_at_m` diagnostic), turning a one-sided hash into a concrete
+/// list of missing / extra / differing rows.
+async fn debug_catchup_rows_handler(
+    State(state): State<AppState>,
+    Path(table): Path<String>,
+) -> impl IntoResponse {
+    let circuit = state.processor.read().await;
+    let rows: serde_json::Map<String, Value> = circuit
+        .dump_table_rows(&table)
+        .into_iter()
+        .collect();
+    Json(json!({ "table": table, "rows": rows }))
 }
 
 /// Debug dependency map handler

--- a/example/api/package.json
+++ b/example/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-api",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:example": "pnpm dev",

--- a/example/app-solid/package.json
+++ b/example/app-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/app-solid",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Solid.js Thread Application with Authentication",
   "type": "module",
   "scripts": {

--- a/example/e2e/package.json
+++ b/example/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/e2e",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "scripts": {
     "test": "playwright test",

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/project",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "description": "Example Sp00ky project",
   "scripts": {

--- a/example/schema/package.json
+++ b/example/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/schema",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Database schema and types for SurrealDB",
   "keywords": [
     "database",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp00ky",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "description": "Sp00ky monorepo",
   "scripts": {

--- a/packages/client-solid/package.json
+++ b/packages/client-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/client-solid",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "type": "module",
   "description": "SurrealDB client with local and remote database support for browser applications",
   "main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/core",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/job-runner/Cargo.toml
+++ b/packages/job-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job-runner"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 
 [dependencies]

--- a/packages/query-builder/package.json
+++ b/packages/query-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/query-builder",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "description": "Type-safe query builder for SurrealDB with relationship support",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/spooky_core/pubspec.yaml
+++ b/packages/spooky_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spooky_core
 description: Pure-Dart core for Spooky local-first sync (framework-agnostic).
-version: 0.0.1-canary.113
+version: 0.0.1-canary.114
 publish_to: none
 
 environment:

--- a/packages/ssp-ffi/Cargo.toml
+++ b/packages/ssp-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-ffi"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 description = "C ABI (Dart FFI) bindings for ssp"
 license = "MIT"

--- a/packages/ssp-protocol/Cargo.toml
+++ b/packages/ssp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-protocol"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 
 [dependencies]

--- a/packages/ssp-wasm/Cargo.toml
+++ b/packages/ssp-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-wasm"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 description = "WASM bindings for ssp"
 license = "MIT"

--- a/packages/ssp-wasm/package.json
+++ b/packages/ssp-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/ssp-wasm",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "main": "pkg/ssp_wasm.js",
   "types": "pkg/ssp_wasm.d.ts",
   "files": [

--- a/packages/ssp/Cargo.toml
+++ b/packages/ssp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.0.1-canary.113"
+version = "0.0.1-canary.114"
 edition = "2021"
 
 [lib]

--- a/packages/ssp/src/circuit/circuit.rs
+++ b/packages/ssp/src/circuit/circuit.rs
@@ -974,6 +974,23 @@ impl Circuit {
     pub fn dependency_map_dump(&self) -> &HashMap<String, Vec<String>> {
         &self.dependency_map
     }
+
+    /// Dump a table's circuit rows as `(raw_id, json)` pairs — the exact values
+    /// that feed the catch-up XOR set-hash. The scheduler pulls this on a
+    /// persistent catch-up mismatch (`/debug/catchup-rows/:table`) to diff its
+    /// reconstructed projection row-by-row against the circuit, so an operator
+    /// can see the specific diverging (or missing/extra) row instead of guessing
+    /// from a one-sided hash. Returns an empty vec for an unknown table.
+    pub fn dump_table_rows(&self, table: &str) -> Vec<(String, serde_json::Value)> {
+        match self.store.collections.get(table) {
+            Some(coll) => coll
+                .rows
+                .iter()
+                .map(|(id, val)| (id.clone(), serde_json::Value::from(val.clone())))
+                .collect(),
+            None => Vec::new(),
+        }
+    }
 }
 
 impl Default for Circuit {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spooky-sync/tests",
-  "version": "0.0.1-canary.113",
+  "version": "0.0.1-canary.114",
   "private": true,
   "scripts": {
     "test": "jest --runInBand",


### PR DESCRIPTION
## Problem

A **deterministic** scheduler-vs-circuit catch-up hash gap (seen on the `job` / `statistics_job` outbox tables) makes an SSP re-bootstrap forever: `verify_catchup_at_m` fails, forces a resync, the SSP refetches the *identical* diverging state, and fails again. Nothing counts the failures and the `spky dev` supervisor exempts integrity resyncs from the crash cap, so the cluster sits with **no ready SSP and every live query failing** (observed on staging 2026-07-05, 14 cycles in ~2 min).

This is NOT the canary.98 null/`_00_rv` asymmetry (that strip is already active). A plain re-bootstrap can never fix a deterministic representation gap.

## Fix

**Circuit-breaker** (per-SSP consecutive catch-up failure counter):
- after `SPKY_CATCHUP_RECLONE_AFTER` (default 3) failures, re-clone the replica from upstream once (serialized by a shared lock), then flag all SSPs to re-bootstrap from the fresh snapshot;
- after `SPKY_CATCHUP_ADMIT_AFTER` (default 5), admit the SSP to broadcast anyway with a loud alert, restoring sync. Set equal to skip re-clone; set admit huge to disable admit.

**Both-sides diagnostic**: new SSP endpoint `GET /debug/catchup-rows/:table` dumps the circuit's rows; `verify_catchup_at_m` fetches it and logs the real row-level diff (missing / extra / differing rows with canonical JSON) instead of the old one-sided dump. Falls back to the one-sided dump on older SSP builds, so no strict co-deploy order (breaker is scheduler-only). This will finally reveal the exact diverging field.

Also gates the misleading "fully caught up and ready" log on actual verification success.

## Tests

`cargo test -p scheduler --lib` (17, incl. 3 new: pool counter + threshold flooring), `ssp-protocol` + `ssp --lib` (20) green. Both binaries build clean.

Note: `apps/scheduler/tests/integration.rs` had pre-existing `MetricsState` field drift (since canary.58); only the `SspManagementState` literal was updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)