### PR TITLE
feat(devtools): feature flag control from the Flags tab

### DIFF
--- a/apps/cli/src/admin.rs
+++ b/apps/cli/src/admin.rs
@@ -1,0 +1,229 @@
+//! `spky admin` — manage the sp00ky operator roster (`_00_admin`).
+//!
+//! The `user` table belongs to the app, not to sp00ky, so there is no `role`
+//! field we can rely on — and a self-writable one would be a privilege
+//! escalation hole. `_00_admin` is the whole admin concept instead: a row
+//! there means "may edit feature flags from the DevTools panel".
+//!
+//! The table denies create/update/delete unconditionally, so it can only be
+//! written by root — i.e. by this command. Nobody promotes themselves.
+//!
+//! What an admin can actually do is defined in `meta_tables_remote.surql`:
+//! read `_00_feature_flag`, flip `enabled`, edit allowlist rules via
+//! `fn::feature::allow` / `fn::feature::disallow`, and write the
+//! `_00_user_feature` rows those functions materialize. Creating and deleting
+//! flags stays root-only (`spky flag create|delete`).
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::path::PathBuf;
+
+use crate::flag::{client_from, esc, load_user_id, rows};
+use crate::surreal_client::MigrationDB;
+use crate::AdminCommands;
+
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+pub fn run(action: AdminCommands) -> Result<()> {
+    match action {
+        AdminCommands::List { conn, config } => list(conn, config),
+        AdminCommands::Add {
+            user,
+            note,
+            conn,
+            config,
+        } => add(user, note, conn, config),
+        AdminCommands::Remove { user, conn, config } => remove(user, conn, config),
+    }
+}
+
+fn list(conn: crate::ConnectionArgs, config: Option<PathBuf>) -> Result<()> {
+    let client = client_from(conn, config)?;
+    let resp = client
+        .execute(
+            "SELECT <string>user AS user, user.username AS username, note, added_at \
+             FROM _00_admin ORDER BY added_at ASC;",
+        )
+        .context("Failed to list admins")?;
+    let admins = rows(resp);
+    if admins.is_empty() {
+        println!("{}No admins. Add one with `spky admin add <user>`.{}", DIM, RESET);
+        return Ok(());
+    }
+    println!("{}USER                      ID                        NOTE{}", BOLD, RESET);
+    for a in admins {
+        let username = a
+            .get("username")
+            .and_then(Value::as_str)
+            .unwrap_or("(deleted)");
+        let id = a.get("user").and_then(Value::as_str).unwrap_or("?");
+        let note = a.get("note").and_then(Value::as_str).unwrap_or("");
+        println!("{:<25} {:<25} {}", username, id, note);
+    }
+    Ok(())
+}
+
+fn add(
+    user: String,
+    note: Option<String>,
+    conn: crate::ConnectionArgs,
+    config: Option<PathBuf>,
+) -> Result<()> {
+    let client = client_from(conn, config)?;
+    // Accepts a username or a `user:xxx` record id.
+    let user_id = load_user_id(&client, &user)?;
+
+    // `user_id` is a DB-sourced record id and is interpolated as a record
+    // reference (the same shape `flag.rs::materialize` uses); the note is
+    // escaped as a string literal.
+    let note_sql = match &note {
+        Some(n) => format!("'{}'", esc(n)),
+        None => "NONE".to_string(),
+    };
+    let query = format!(
+        "UPSERT _00_admin SET user = {uid}, note = {note} WHERE user = {uid};",
+        uid = user_id,
+        note = note_sql
+    );
+    client
+        .execute(&query)
+        .context("Failed to add admin. Has the internal schema been applied (`spky migrate`)?")?;
+
+    println!(
+        "{}Added{} '{}' ({}) as an admin.",
+        GREEN, RESET, user, user_id
+    );
+    println!(
+        "{}They can now edit feature flags from the DevTools Flags tab. No re-login needed —\n\
+         $auth.id is evaluated per query.{}",
+        DIM, RESET
+    );
+    Ok(())
+}
+
+fn remove(user: String, conn: crate::ConnectionArgs, config: Option<PathBuf>) -> Result<()> {
+    let client = client_from(conn, config)?;
+    let user_id = load_user_id(&client, &user)?;
+
+    let existing = rows(
+        client
+            .execute(&format!(
+                "SELECT VALUE id FROM _00_admin WHERE user = {};",
+                user_id
+            ))
+            .context("Failed to check admin roster")?,
+    );
+    if existing.is_empty() {
+        println!("{}'{}' is not an admin. Nothing to do.{}", YELLOW, user, RESET);
+        return Ok(());
+    }
+
+    client
+        .execute(&format!("DELETE _00_admin WHERE user = {};", user_id))
+        .context("Failed to remove admin")?;
+
+    println!("{}Removed{} '{}' from the admin roster.", GREEN, RESET, user);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const META_TABLES_REMOTE: &str = include_str!("meta_tables_remote.surql");
+
+    /// `DEFINE FUNCTION` defaults to `PERMISSIONS FULL` in SurrealDB — omitting
+    /// the clause does NOT make a function root-only, it exposes it to every
+    /// signed-in user. `fn::feature::materialize` / `allow` / `disallow` write
+    /// flags for ALL users, so a missing clause here ships a self-service flag
+    /// editor. `fn::feature::hash` is pure and deliberately callable.
+    ///
+    /// This is a string check on purpose: it fails at `cargo test` rather than
+    /// after a deploy, and it needs no database.
+    #[test]
+    fn every_feature_mutation_function_declares_permissions() {
+        let mutating = ["materialize", "allow", "disallow"];
+        for name in mutating {
+            let marker = format!("DEFINE FUNCTION OVERWRITE fn::feature::{name}(");
+            let start = META_TABLES_REMOTE
+                .find(&marker)
+                .unwrap_or_else(|| panic!("fn::feature::{name} is missing from the schema"));
+            // The body ends at the next DEFINE; the PERMISSIONS clause sits
+            // between the closing brace and that boundary.
+            let rest = &META_TABLES_REMOTE[start + marker.len()..];
+            let end = rest.find("\nDEFINE ").unwrap_or(rest.len());
+            assert!(
+                rest[..end].contains("PERMISSIONS WHERE"),
+                "fn::feature::{name} has no PERMISSIONS clause, so SurrealDB defaults it to \
+                 FULL and any signed-in user can rewrite feature flags"
+            );
+        }
+    }
+
+    /// The admin gate is repeated in four places (two tables, three functions).
+    /// If one copy drifts, that gate opens wider than the others and nothing
+    /// else would notice.
+    #[test]
+    fn the_admin_predicate_is_identical_everywhere() {
+        let predicate =
+            "array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0";
+        assert_eq!(
+            META_TABLES_REMOTE.matches(predicate).count(),
+            5,
+            "expected the admin predicate on _00_feature_flag, _00_user_feature and the three \
+             fn::feature::* mutations — a differing count means one gate has drifted"
+        );
+    }
+
+    /// `_00_admin` must never become client-writable: the whole point is that
+    /// nobody can promote themselves.
+    #[test]
+    fn admin_roster_denies_client_writes() {
+        let start = META_TABLES_REMOTE
+            .find("DEFINE TABLE OVERWRITE _00_admin")
+            .expect("_00_admin table definition missing");
+        let rest = &META_TABLES_REMOTE[start..];
+        let end = rest.find("\nDEFINE FIELD").unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("FOR create, update, delete NONE"),
+            "_00_admin must deny create/update/delete to record tokens"
+        );
+    }
+
+    /// The record id must be interpolated as a record reference, not quoted:
+    /// `user = 'user:abc'` compares a string against a `record` field and
+    /// silently matches nothing, which would make `add` a no-op and `remove`
+    /// claim the user isn't an admin.
+    #[test]
+    fn add_interpolates_the_record_id_unquoted() {
+        let uid = "user:abc";
+        let query = format!(
+            "UPSERT _00_admin SET user = {uid}, note = {note} WHERE user = {uid};",
+            uid = uid,
+            note = "NONE"
+        );
+        assert!(query.contains("SET user = user:abc,"));
+        assert!(query.contains("WHERE user = user:abc;"));
+        assert!(!query.contains("'user:abc'"));
+    }
+
+    #[test]
+    fn note_is_escaped_as_a_string_literal() {
+        let note_sql = format!("'{}'", esc("it's fine"));
+        assert_eq!(note_sql, "'it\\'s fine'");
+    }
+
+    #[test]
+    fn absent_note_writes_none_not_an_empty_string() {
+        let note: Option<String> = None;
+        let note_sql = match &note {
+            Some(n) => format!("'{}'", esc(n)),
+            None => "NONE".to_string(),
+        };
+        assert_eq!(note_sql, "NONE");
+    }
+}

--- a/apps/cli/src/flag.rs
+++ b/apps/cli/src/flag.rs
@@ -2,9 +2,13 @@
 //!
 //! Writes flag definitions to `_00_feature_flag` and materializes per-user
 //! assignments into `_00_user_feature` by running the evaluator in-process.
-//! Both tables are root-only (PERMISSIONS NONE on definitions, NONE on
-//! create/update/delete for assignments), so clients cannot self-enable or
-//! see other users' rows.
+//!
+//! Ordinary clients can neither read the definitions nor write assignments:
+//! `_00_feature_flag` is invisible to them and `_00_user_feature` is
+//! read-your-own. Users listed in `_00_admin` (see `spky admin`) are the one
+//! exception — they can flip `enabled` and edit allowlist rules from the
+//! DevTools panel via `fn::feature::materialize`. Flag creation and deletion
+//! stay root-only, i.e. this command.
 //!
 //! The percentage-rollout hash here must match `fn::feature::hash` in
 //! `apps/cli/src/meta_tables_remote.surql`. Both sides take the first 8
@@ -75,7 +79,7 @@ pub fn run(action: FlagCommands) -> Result<()> {
 // Connection
 // =============================================================
 
-fn client_from(conn: ConnectionArgs, config: Option<PathBuf>) -> Result<SurrealClient> {
+pub(crate) fn client_from(conn: ConnectionArgs, config: Option<PathBuf>) -> Result<SurrealClient> {
     // `--cloud` resolves the deployment's SurrealDB URL + root password from
     // Sp00ky Cloud; otherwise the local URL/ns/db come from sp00ky.yml.
     let c = conn.resolve(&config)?;
@@ -92,11 +96,11 @@ fn client_from(conn: ConnectionArgs, config: Option<PathBuf>) -> Result<SurrealC
 // SurrealQL helpers
 // =============================================================
 
-fn esc(s: &str) -> String {
+pub(crate) fn esc(s: &str) -> String {
     s.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
-fn first_row(responses: Vec<SurrealResponse>) -> Option<Value> {
+pub(crate) fn first_row(responses: Vec<SurrealResponse>) -> Option<Value> {
     let first = responses.into_iter().next()?;
     let result = first.result?;
     match result {
@@ -105,7 +109,7 @@ fn first_row(responses: Vec<SurrealResponse>) -> Option<Value> {
     }
 }
 
-fn rows(responses: Vec<SurrealResponse>) -> Vec<Value> {
+pub(crate) fn rows(responses: Vec<SurrealResponse>) -> Vec<Value> {
     let first = match responses.into_iter().next() {
         Some(r) => r,
         None => return vec![],
@@ -126,7 +130,7 @@ fn load_flag(client: &SurrealClient, key: &str) -> Result<Value> {
     first_row(resp).ok_or_else(|| anyhow!("Flag '{}' not found", key))
 }
 
-fn load_user_id(client: &SurrealClient, who: &str) -> Result<String> {
+pub(crate) fn load_user_id(client: &SurrealClient, who: &str) -> Result<String> {
     if who.starts_with("user:") {
         return Ok(who.to_string());
     }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod add_api;
+mod admin;
 mod agents;
 mod annotations;
 mod backend;
@@ -360,6 +361,11 @@ enum Commands {
         #[command(subcommand)]
         action: FlagCommands,
     },
+    /// Manage who may edit feature flags from the DevTools panel
+    Admin {
+        #[command(subcommand)]
+        action: AdminCommands,
+    },
     /// Inspect and control server-side schedules (`schedules:` in sp00ky.yml)
     Schedules {
         #[command(flatten)]
@@ -456,6 +462,48 @@ enum AgentsCommands {
         /// Write to this path instead of `<project>/AGENTS.md`.
         #[arg(long)]
         out: Option<PathBuf>,
+    },
+}
+
+/// `spky admin` — the sp00ky operator roster (`_00_admin`).
+///
+/// Root-only by construction: the table denies create/update/delete to every
+/// record token, so this command is the only way in or out. An admin may read
+/// flag definitions and flip flags from the DevTools panel; creating and
+/// deleting flags stays with `spky flag`.
+#[derive(Subcommand, Debug)]
+enum AdminCommands {
+    /// List the current admins
+    #[command(visible_alias = "ls")]
+    List {
+        #[command(flatten)]
+        conn: ConnectionArgs,
+        /// Path to sp00ky.yml config file
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+    /// Grant a user admin rights over feature flags
+    Add {
+        /// Username or `user:xxx` record id
+        user: String,
+        /// Optional note (e.g. why, or who asked)
+        #[arg(long)]
+        note: Option<String>,
+        #[command(flatten)]
+        conn: ConnectionArgs,
+        /// Path to sp00ky.yml config file
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+    /// Revoke a user's admin rights
+    Remove {
+        /// Username or `user:xxx` record id
+        user: String,
+        #[command(flatten)]
+        conn: ConnectionArgs,
+        /// Path to sp00ky.yml config file
+        #[arg(long)]
+        config: Option<PathBuf>,
     },
 }
 
@@ -3051,6 +3099,7 @@ fn main() -> Result<()> {
         Some(Commands::Backup { action }) => cloud::backup(action),
         Some(Commands::Link { action }) => cloud::link(action),
         Some(Commands::Flag { action }) => flag::run(action),
+        Some(Commands::Admin { action }) => admin::run(action),
         Some(Commands::Jobs {
             conn,
             config,

--- a/apps/cli/src/meta_tables_remote.surql
+++ b/apps/cli/src/meta_tables_remote.surql
@@ -120,14 +120,69 @@ DEFINE INDEX OVERWRITE idx_record_id ON TABLE _00_version COLUMNS record_id UNIQ
 -- feed without a follow-up subquery.
 
 -- ==================================================
--- SPOOKY FEATURE FLAG (definitions)
--- Root-only. Record-token callers can neither read nor write, so
--- targeting rules (including allowlisted user records) are never on
--- the client. The scheduler and the `spky flag` CLI write here using
--- the project root token; the scheduler recomputes _00_user_feature
--- assignments whenever a row changes.
+-- SPOOKY ADMIN (operator roster)
+-- The `user` table belongs to the app, not to sp00ky, so we can't gate
+-- on a `role` field that may not exist — and a self-writable role field
+-- would be a privilege-escalation hole anyway. This table is the whole
+-- admin concept: a row here means "may edit feature flags from the
+-- DevTools panel".
+--
+-- Root-written ONLY, via `spky admin add|remove|list`. create/update/
+-- delete are denied unconditionally, so a record token cannot insert its
+-- own row even with a forged mutation. Nobody self-promotes.
+--
+-- SELECT is scoped to the caller's OWN row (same shape as
+-- _00_user_feature below). That lets the panel answer "am I an admin?"
+-- with one query while the roster itself stays unreadable: a non-admin
+-- gets [], an admin gets exactly one row — their own.
+--
+-- The _00_feature_flag / _00_user_feature rules below read this table
+-- from INSIDE a PERMISSIONS clause. SurrealDB computes permission
+-- predicates with permission checks disabled on the nested Options
+-- (surrealdb-core `doc/check.rs::process_permissions` does
+-- `opt.new_with_perms(false)`), so that subquery sees every row
+-- regardless of the self-scoped rule here. The membership test works
+-- without the roster ever being readable by a non-admin.
+--
+-- MUST NEVER join `ssp_protocol::SYNCED_META_TABLES`: the SSP injects NO
+-- permission filter for `_00_*` tables (packages/ssp/src/
+-- permission_inject.rs returns Ok(None) for them), so syncing this would
+-- publish the whole roster unfiltered to any client that registers a
+-- query on it.
 -- ==================================================
-DEFINE TABLE OVERWRITE _00_feature_flag SCHEMAFULL PERMISSIONS NONE;
+DEFINE TABLE OVERWRITE _00_admin SCHEMAFULL
+    PERMISSIONS
+      FOR select WHERE user = $auth.id
+      FOR create, update, delete NONE;
+
+DEFINE FIELD OVERWRITE user ON TABLE _00_admin TYPE record;
+DEFINE FIELD OVERWRITE note ON TABLE _00_admin TYPE option<string>;
+DEFINE FIELD OVERWRITE added_at ON TABLE _00_admin TYPE datetime DEFAULT time::now() READONLY;
+DEFINE INDEX OVERWRITE idx_admin_user ON TABLE _00_admin COLUMNS user UNIQUE;
+
+-- ==================================================
+-- SPOOKY FEATURE FLAG (definitions)
+-- Readable and updatable by admins (see _00_admin above), invisible to
+-- everyone else — a non-admin's SELECT silently returns zero rows and
+-- never learns the table exists, so targeting rules (including
+-- allowlisted user records) still never reach an ordinary client.
+--
+-- create/delete stay root-only: `spky flag create|delete` owns the
+-- lifecycle. The DevTools panel only flips `enabled` and edits `rules`,
+-- both of which are UPDATEs.
+--
+-- The membership test is an indexed point lookup on _00_admin
+-- (idx_admin_user). The `$auth.id != NONE` guard keeps anonymous live
+-- queries out. Keep this predicate byte-identical to the one on
+-- _00_user_feature and on the fn::feature::* functions below — if the
+-- four ever drift, one gate opens wider than the others.
+-- ==================================================
+DEFINE TABLE OVERWRITE _00_feature_flag SCHEMAFULL
+    PERMISSIONS
+      FOR select, update
+        WHERE $auth.id != NONE
+          AND array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0
+      FOR create, delete NONE;
 
 DEFINE FIELD OVERWRITE key ON TABLE _00_feature_flag TYPE string;
 DEFINE FIELD OVERWRITE description ON TABLE _00_feature_flag TYPE option<string>;
@@ -149,14 +204,27 @@ DEFINE INDEX OVERWRITE idx_feature_flag_key ON TABLE _00_feature_flag COLUMNS ke
 
 -- ==================================================
 -- SPOOKY USER FEATURE (per-user materialized assignments)
--- Record-token callers can SELECT only their own rows. Writes are
--- root-only: clients cannot self-enable a flag even with a forged
--- mutation, because create/update/delete are denied unconditionally.
+-- Record-token callers can SELECT only their own rows: an ordinary
+-- client cannot self-enable a flag, and cannot see anyone else's.
+--
+-- Writes are open to ADMINS (and root), not to ordinary users. This is
+-- load-bearing and must not be "tightened" back to NONE: a SurrealDB
+-- custom function is NOT security-definer — `fn::feature::materialize`
+-- below runs its UPSERTs under the CALLER's permissions (surrealdb-core
+-- computes a function body with the caller's Options; the AuthLimit it
+-- applies is a cap, never a grant). With `FOR create, update, delete
+-- NONE` an admin calling materialize from the browser would fail on
+-- every row.
+--
+-- An admin being able to write assignment rows is inside the trust they
+-- already hold: they can flip the flag those rows are derived from.
 -- ==================================================
 DEFINE TABLE OVERWRITE _00_user_feature SCHEMAFULL
     PERMISSIONS
       FOR select WHERE user = $auth.id
-      FOR create, update, delete NONE;
+      FOR create, update, delete
+        WHERE $auth.id != NONE
+          AND array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0;
 
 DEFINE FIELD OVERWRITE user ON TABLE _00_user_feature TYPE record;
 DEFINE FIELD OVERWRITE key ON TABLE _00_user_feature TYPE string;
@@ -170,9 +238,207 @@ DEFINE INDEX OVERWRITE idx_user_feature_user_key ON TABLE _00_user_feature COLUM
 -- across deploys. Implementation matches the Rust evaluator in
 -- `apps/cli/src/flag.rs::rollout_hash`: SHA-256, then read the first 8
 -- hex chars as an unsigned 32-bit integer modulo 100.
+--
+-- The hex digits are folded by hand rather than cast. SurrealDB 3 removed
+-- hex support from the int cast — `<int>'0x5f7bdee4'` fails with "Could
+-- not cast into `int`", and `0x5f7bdee4` is no longer even a valid token —
+-- so the original one-liner errors on every call. Nothing exercised it
+-- before (both Rust evaluators hash themselves and the CLI never called
+-- it), which is why it went unnoticed; `fn::feature::materialize` below
+-- does call it, so every rollout rule depends on this being correct.
+-- `string::split(s, '')` yields empty strings at both ends, hence the
+-- filter. The golden vectors in `flag.rs::rollout_hash_matches_golden_vectors`
+-- are asserted against this implementation.
 DEFINE FUNCTION OVERWRITE fn::feature::hash($key: string, $user_id: string) -> int {
-  RETURN <int> (<int> ('0x' + string::slice(crypto::sha256($key + ':' + $user_id), 0, 8))) % 100;
+  LET $hex = string::slice(crypto::sha256($key + ':' + $user_id), 0, 8);
+  LET $digits = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'];
+  LET $chars = array::filter(string::split($hex, ''), |$c| $c != '');
+  RETURN array::fold($chars, 0, |$acc, $c| $acc * 16 + array::find_index($digits, $c)) % 100;
 };
+
+-- ==================================================
+-- ADMIN-CALLABLE FEATURE FLAG MUTATIONS
+--
+-- These exist so the DevTools panel can flip a flag from the browser.
+-- `spky flag` does the same work in Rust and does NOT call them.
+--
+-- Two SurrealDB facts drive the shape of everything below:
+--
+--   1. DEFINE FUNCTION defaults to PERMISSIONS FULL. Omitting the clause
+--      does NOT make a function root-only — it ships a self-service flag
+--      editor to every signed-in user. Each function here therefore
+--      carries an explicit PERMISSIONS clause, identical to the one on
+--      _00_feature_flag / _00_user_feature. (The `fn::job::*` functions
+--      in functions_remote_singlenode.surql claim otherwise in a comment;
+--      that comment is wrong and is tracked separately.)
+--
+--   2. A custom function is NOT security-definer: its body runs under the
+--      CALLER's permissions. That is why _00_user_feature grants writes to
+--      admins, and why the `SELECT VALUE id FROM user` below is subject to
+--      the app's own `user` table SELECT rule — see the guard in
+--      fn::feature::materialize.
+--
+-- Root bypasses permission checks entirely, so the CLI and the scheduler
+-- are unaffected by the clauses.
+-- ==================================================
+
+-- Re-evaluate ONE flag for EVERY user and refresh `_00_user_feature`.
+-- Faithful port of the Rust evaluator (`apps/cli/src/flag.rs::evaluate_one`
+-- and `apps/scheduler/src/feature_flags.rs::evaluate_one`); the golden
+-- vectors pinned in both Rust test suites are asserted against this
+-- implementation too, so drift fails a test rather than silently
+-- assigning different variants depending on who flipped the flag.
+DEFINE FUNCTION OVERWRITE fn::feature::materialize($key: string) -> object {
+    LET $flag = (SELECT * FROM ONLY _00_feature_flag WHERE key = $key LIMIT 1);
+
+    -- Unknown/deleted flag: drop the orphaned assignments, mirroring the
+    -- load_flag-failed branch of `flag.rs::materialize`.
+    IF $flag = NONE {
+        DELETE _00_user_feature WHERE key = $key;
+        RETURN { key: $key, found: false, users: 0 };
+    };
+
+    LET $default  = $flag.default_variant ?? 'off';
+    LET $payloads = $flag.payloads ?? {};
+    -- `enabled = false` => everyone gets default_variant, rules ignored.
+    LET $rules    = IF ($flag.enabled ?? true) { $flag.rules ?? [] } ELSE { [] };
+
+    -- Normalise the rules ONCE (they don't depend on the user).
+    --   rank  — priority ascending, original position as tiebreak, because
+    --           Rust sorts with the stable `sort_by_key`. 100 is the
+    --           missing-priority default; the CLI writes 10 (allowlist)
+    --           and 50 (rollout).
+    --   users — `rules[].users` holds STRINGS on disk (`flag.rs` pushes
+    --           Value::String and interpolates the JSON verbatim), so a
+    --           record-vs-array compare would never match. Cast both
+    --           sides to string and a hand-written record element works
+    --           too.
+    LET $ranked = array::map($rules, |$r, $i| {
+        RETURN {
+            rank: (<int>($r.priority ?? 100)) * 100000 + $i,
+            kind: $r.kind,
+            variant: $r.variant,
+            percent: <int>($r.percent ?? 0),
+            users: array::map($r.users ?? [], |$x| <string>$x)
+        };
+    });
+
+    LET $users = (SELECT VALUE id FROM user);
+
+    -- The SELECT above runs under the CALLER's permissions (fact 2). Every
+    -- shipped schema template uses `FOR create, select WHERE true` on
+    -- `user`, but an app that scopes user selects to `id = $auth.id` would
+    -- return just the admin — materializing one row and leaving everyone
+    -- else on the old variant, with no error. The scheduler stamps the
+    -- root-enumerated count each sweep precisely so we can catch that.
+    LET $expected = _00_module_state:feature_user_count.count ?? 0;
+    IF array::len($users) < $expected {
+        THROW "fn::feature::materialize can only see " + <string>array::len($users) + " of "
+            + <string>$expected + " users, so it would leave most of them on a stale variant. "
+            + "The `user` table's SELECT permission is hiding rows from this admin — widen it, "
+            + "or change the flag with `spky flag` instead.";
+    };
+
+    FOR $u IN $users {
+        LET $uid = <string>$u;
+
+        LET $matched = array::filter($ranked, |$c| {
+            RETURN IF $c.variant = NONE { false }
+                ELSE IF $c.kind = 'allowlist' { $uid IN $c.users }
+                ELSE IF $c.kind = 'rollout' {
+                    $c.percent > 0 AND fn::feature::hash($key, $uid) < $c.percent
+                }
+                ELSE { false };
+        });
+
+        -- First match wins = lowest rank. Avoids `SELECT … ORDER BY` over an
+        -- array, which SurrealDB 3 rejects when the ORDER BY field isn't in
+        -- the projection.
+        LET $best    = array::min(array::map($matched, |$c| $c.rank));
+        LET $win     = array::first(array::filter($matched, |$c| $c.rank = $best));
+        LET $variant = IF $win = NONE { $default } ELSE { $win.variant };
+
+        UPSERT _00_user_feature
+            SET user = $u, key = $key, variant = $variant, payload = $payloads[$variant]
+            WHERE user = $u AND key = $key;
+    };
+
+    RETURN { key: $key, found: true, users: array::len($users) };
+}
+PERMISSIONS WHERE $auth.id != NONE
+    AND array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0;
+
+-- Add `$user` to `$key`'s allowlist for `$variant`, then re-materialize.
+-- Rule shape and priority (10) must stay identical to
+-- `apps/cli/src/flag.rs::upsert_allowlist` / PRIORITY_ALLOWLIST. The rule
+-- object is rebuilt field-by-field rather than merged, because an
+-- allowlist rule only ever carries these four keys.
+--
+-- This is a read-modify-write over the whole `rules` array (the same shape
+-- `spky flag set` uses). Two admins acting on one flag at the same moment
+-- therefore collide — but SurrealDB fails the loser with "Transaction
+-- conflict ... can be retried" instead of dropping the write, so no entry is
+-- silently lost. The DevTools bridge retries on that error
+-- (`FlagsAdminService.mutate`); a caller using these functions directly
+-- should do the same.
+DEFINE FUNCTION OVERWRITE fn::feature::allow($key: string, $variant: string, $user: record) -> object {
+    LET $flag = (SELECT * FROM ONLY _00_feature_flag WHERE key = $key LIMIT 1);
+    IF $flag = NONE { THROW "Unknown flag: " + $key };
+    IF !($variant IN ($flag.variants ?? [])) {
+        THROW "Unknown variant '" + $variant + "' for flag '" + $key + "'";
+    };
+
+    LET $uid   = <string>$user;
+    LET $rules = $flag.rules ?? [];
+    LET $has   = array::len(array::filter($rules, |$r| {
+        RETURN $r.kind = 'allowlist' AND $r.variant = $variant;
+    })) > 0;
+
+    LET $next = IF $has {
+        array::map($rules, |$r| {
+            RETURN IF $r.kind = 'allowlist' AND $r.variant = $variant {
+                {
+                    kind: 'allowlist',
+                    variant: $r.variant,
+                    users: array::distinct(array::append(array::map($r.users ?? [], |$x| <string>$x), $uid)),
+                    priority: $r.priority ?? 10
+                }
+            } ELSE { $r };
+        })
+    } ELSE {
+        array::append($rules, { kind: 'allowlist', variant: $variant, users: [$uid], priority: 10 })
+    };
+
+    UPDATE _00_feature_flag SET rules = $next WHERE key = $key;
+    RETURN fn::feature::materialize($key);
+}
+PERMISSIONS WHERE $auth.id != NONE
+    AND array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0;
+
+-- Remove `$user` from every allowlist rule on `$key`, then re-materialize.
+-- Mirrors `spky flag unset --for-user`: the rule is kept (possibly with an
+-- empty `users`), only the membership goes.
+DEFINE FUNCTION OVERWRITE fn::feature::disallow($key: string, $user: record) -> object {
+    LET $flag = (SELECT * FROM ONLY _00_feature_flag WHERE key = $key LIMIT 1);
+    IF $flag = NONE { THROW "Unknown flag: " + $key };
+
+    LET $uid  = <string>$user;
+    LET $next = array::map($flag.rules ?? [], |$r| {
+        RETURN IF $r.kind = 'allowlist' {
+            {
+                kind: 'allowlist',
+                variant: $r.variant,
+                users: array::filter(array::map($r.users ?? [], |$x| <string>$x), |$x| $x != $uid),
+                priority: $r.priority ?? 10
+            }
+        } ELSE { $r };
+    });
+
+    UPDATE _00_feature_flag SET rules = $next WHERE key = $key;
+    RETURN fn::feature::materialize($key);
+}
+PERMISSIONS WHERE $auth.id != NONE
+    AND array::len((SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1)) > 0;
 
 -- ==================================================
 -- SPOOKY APP RELEASE (per-frontend "current version" announcements)

--- a/apps/cli/tests/feature_materialize_e2e.rs
+++ b/apps/cli/tests/feature_materialize_e2e.rs
@@ -1,0 +1,464 @@
+//! End-to-end test for the SurrealQL feature-flag evaluator.
+//!
+//! `fn::feature::materialize` in `meta_tables_remote.surql` is a **fourth**
+//! implementation of the evaluator, alongside `flag.rs::evaluate_one`,
+//! `apps/scheduler/src/feature_flags.rs::evaluate_one`, and the bucketing in
+//! `fn::feature::hash`. It exists so an admin can flip a flag from the DevTools
+//! panel without shelling out to the CLI.
+//!
+//! Four implementations only stay in agreement if drift fails a test, so this
+//! asserts the *same* golden hash vectors and the *same* `evaluate_one`
+//! behaviours that `flag.rs`'s unit tests pin in Rust. If a variant resolves
+//! differently depending on who flipped the flag, that is the bug this catches.
+//!
+//! It also covers the two gates the DevTools tab depends on:
+//!   - a non-admin record token can neither read definitions nor call the
+//!     mutation functions, and cannot forge a `_00_user_feature` row;
+//!   - an admin can, but still cannot promote themselves.
+//!
+//! Requires SurrealDB **3.x**: the evaluator uses closures, `array::fold` and
+//! `array::find_index`, and v3 removed the hex int cast the old
+//! `fn::feature::hash` one-liner relied on.
+//!
+//! Marked `#[ignore]` so the default `cargo test` stays fast and CI-safe:
+//!
+//! ```sh
+//! cargo test -p sp00ky-cli --test feature_materialize_e2e -- --ignored
+//! ```
+//!
+//! Skips (rather than fails) when Docker is unavailable, mirroring
+//! `flag_sql_e2e.rs`.
+
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+const IMAGE: &str = "surrealdb/surrealdb:v3.1.0-beta.3";
+const NAME: &str = "spky-feature-materialize-e2e";
+const PORT: &str = "18078";
+const AUTH: &str = "Basic cm9vdDpyb290"; // base64("root:root")
+const NS: &str = "e2e";
+const DB: &str = "e2e";
+
+/// The internal schema the CLI applies. Sliced at runtime so the test always
+/// exercises the shipped definitions rather than a copy that can rot.
+const META_TABLES: &str = include_str!("../src/meta_tables_remote.surql");
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn remove_container() {
+    let _ = Command::new("docker")
+        .args(["rm", "-f", NAME])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+struct Container;
+impl Drop for Container {
+    fn drop(&mut self) {
+        remove_container();
+    }
+}
+
+/// POST to `/sql` as root. `None` on a transport error (server not up yet).
+fn try_sql(query: &str) -> Option<String> {
+    post(query, AUTH)
+}
+
+fn post(query: &str, auth: &str) -> Option<String> {
+    let url = format!("http://127.0.0.1:{PORT}/sql");
+    match ureq::post(&url)
+        .set("Authorization", auth)
+        .set("surreal-ns", NS)
+        .set("surreal-db", DB)
+        .set("Accept", "application/json")
+        .send_string(query)
+    {
+        Ok(r) => Some(r.into_string().unwrap_or_default()),
+        Err(ureq::Error::Status(_, r)) => Some(r.into_string().unwrap_or_default()),
+        Err(_) => None,
+    }
+}
+
+fn sql(query: &str) -> String {
+    try_sql(query).expect("SurrealDB query failed (transport error)")
+}
+
+/// Run a query as a record-access user, using the JWT from `signup`/`signin`.
+fn sql_as(token: &str, query: &str) -> String {
+    post(query, &format!("Bearer {token}")).expect("SurrealDB query failed (transport error)")
+}
+
+/// Sign a user up through the `account` record access and return their JWT.
+fn signup(username: &str) -> String {
+    let url = format!("http://127.0.0.1:{PORT}/signup");
+    let body = format!(
+        r#"{{"NS":"{NS}","DB":"{DB}","AC":"account","username":"{username}","password":"pw12345"}}"#
+    );
+    let resp = ureq::post(&url)
+        .set("Accept", "application/json")
+        .send_string(&body)
+        .expect("signup failed")
+        .into_string()
+        .unwrap_or_default();
+    let token = resp
+        .split("\"token\":\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
+        .unwrap_or_else(|| panic!("no token in signup response: {resp}"));
+    token.to_string()
+}
+
+/// The `_00_admin` → `fn::feature::*` slice of the shipped internal schema.
+///
+/// Applying the whole file would drag in the ingest events and the DBSP
+/// registration hooks, which need an SSP. This takes the feature-flag block
+/// verbatim from the real file, so a change to the shipped SurrealQL is what
+/// this test runs.
+fn feature_schema() -> String {
+    let start = META_TABLES
+        .find("-- SPOOKY ADMIN")
+        .expect("`-- SPOOKY ADMIN` header missing from meta_tables_remote.surql");
+    let start = META_TABLES[..start]
+        .rfind("-- ==")
+        .expect("no comment banner before the SPOOKY ADMIN block");
+    let end = META_TABLES
+        .find("-- SPOOKY APP RELEASE")
+        .expect("`-- SPOOKY APP RELEASE` header missing from meta_tables_remote.surql");
+    let end = META_TABLES[..end]
+        .rfind("-- ==")
+        .expect("no comment banner before the SPOOKY APP RELEASE block");
+    format!(
+        "DEFINE TABLE OVERWRITE _00_module_state SCHEMALESS PERMISSIONS FULL;\n{}",
+        &META_TABLES[start..end]
+    )
+}
+
+/// True when every statement in the response reported `status: OK`.
+fn all_ok(body: &str) -> bool {
+    !body.contains("\"status\":\"ERR\"") && !body.contains("\"code\":400")
+}
+
+fn start_surrealdb() -> Container {
+    remove_container();
+    let started = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--name",
+            NAME,
+            "-p",
+            &format!("{PORT}:8000"),
+            IMAGE,
+            "start",
+            "--user",
+            "root",
+            "--pass",
+            "root",
+            "--allow-all",
+            "memory",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("failed to invoke docker run");
+    assert!(started.success(), "docker run failed for {IMAGE}");
+    let guard = Container;
+
+    let deadline = Instant::now() + Duration::from_secs(90);
+    while try_sql("RETURN 1;").is_none() {
+        assert!(
+            Instant::now() < deadline,
+            "SurrealDB did not become ready within 90s"
+        );
+        sleep(Duration::from_millis(500));
+    }
+    guard
+}
+
+/// Seed an app schema (a `user` table + the `account` access) plus the
+/// feature-flag half of the internal schema.
+fn seed_schema() {
+    // v3 does not auto-create the namespace/database from the request headers.
+    let init = format!(
+        "DEFINE NAMESPACE IF NOT EXISTS {NS}; USE NS {NS}; \
+         DEFINE DATABASE IF NOT EXISTS {DB}; USE NS {NS} DB {DB};"
+    );
+    let body = sql(&init);
+    assert!(all_ok(&body), "failed to create the namespace/database: {body}");
+
+    let app = r#"
+        DEFINE TABLE user SCHEMAFULL
+        PERMISSIONS
+          FOR update, delete WHERE $access = "account" AND id = $auth.id
+          FOR create, select WHERE true;
+        DEFINE FIELD username ON TABLE user TYPE string;
+        DEFINE FIELD password ON TABLE user TYPE string;
+        DEFINE INDEX idx_username ON TABLE user COLUMNS username UNIQUE;
+        DEFINE ACCESS account ON DATABASE TYPE RECORD
+          SIGNUP ( CREATE user SET username = $username, password = crypto::argon2::generate($password) )
+          SIGNIN ( SELECT * FROM user WHERE username = $username AND crypto::argon2::compare(password, $password) )
+          DURATION FOR TOKEN 15m, FOR SESSION 30d;
+    "#;
+    let body = sql(app);
+    assert!(all_ok(&body), "failed to apply the app schema: {body}");
+
+    let body = sql(&feature_schema());
+    assert!(
+        all_ok(&body),
+        "failed to apply the feature-flag internal schema: {body}"
+    );
+}
+
+#[test]
+#[ignore = "requires Docker; run with: cargo test -p sp00ky-cli --test feature_materialize_e2e -- --ignored"]
+fn surrealql_evaluator_matches_the_rust_golden_vectors() {
+    if !docker_available() {
+        eprintln!("skipping feature_materialize_e2e: Docker is not available");
+        return;
+    }
+    let _guard = start_surrealdb();
+    seed_schema();
+
+    // ---- fn::feature::hash --------------------------------------------
+    // The exact values pinned by `flag.rs::rollout_hash_matches_golden_vectors`
+    // and by the scheduler's copy. v3 removed the `<int>'0x…'` cast the
+    // original one-liner used, so this also guards the hand-rolled hex fold.
+    let body = sql(
+        "RETURN [
+            fn::feature::hash('checkout-v2', 'user:alice'),
+            fn::feature::hash('checkout-v2', 'user:bob'),
+            fn::feature::hash('flag-x', 'user:abc'),
+            fn::feature::hash('beta', 'user:42'),
+            fn::feature::hash('rollout', 'user:zzz')
+        ];",
+    );
+    assert!(
+        body.contains("[8,62,0,90,17]") || body.contains("[8, 62, 0, 90, 17]"),
+        "fn::feature::hash drifted from the Rust golden vectors: {body}"
+    );
+
+    sql("CREATE user:abc SET username = 'abc', password = 'x';
+         CREATE user:xyz SET username = 'xyz', password = 'x';
+         CREATE user:alice SET username = 'alice', password = 'x';");
+
+    // ---- disabled flag ignores its rules ------------------------------
+    sql("CREATE _00_feature_flag SET key = 'd1', enabled = false, default_variant = 'off',
+           variants = ['off','on'],
+           rules = [{ kind: 'allowlist', variant: 'on', users: ['user:abc'], priority: 10 }];
+         RETURN fn::feature::materialize('d1');");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'd1' AND user = user:abc;")
+            .contains("\"off\""),
+        "a disabled flag must return default_variant regardless of rules"
+    );
+
+    // ---- rollout 0 never matches, 100 always matches -------------------
+    sql("CREATE _00_feature_flag SET key = 'r0', enabled = true, default_variant = 'off',
+           variants = ['off','on'],
+           rules = [{ kind: 'rollout', variant: 'on', percent: 0, priority: 50 }];
+         CREATE _00_feature_flag SET key = 'r100', enabled = true, default_variant = 'off',
+           variants = ['off','on'],
+           rules = [{ kind: 'rollout', variant: 'on', percent: 100, priority: 50 }];
+         RETURN fn::feature::materialize('r0');
+         RETURN fn::feature::materialize('r100');");
+    let zero = sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'r0';");
+    assert!(!zero.contains("\"on\""), "0% rollout matched someone: {zero}");
+    let hundred = sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'r100';");
+    assert!(
+        !hundred.contains("\"off\""),
+        "100% rollout missed someone: {hundred}"
+    );
+
+    // ---- allowlist beats a lower-priority rollout ----------------------
+    sql("CREATE _00_feature_flag SET key = 'ab', enabled = true, default_variant = 'off',
+           variants = ['off','on'],
+           rules = [
+             { kind: 'rollout', variant: 'on', percent: 0, priority: 50 },
+             { kind: 'allowlist', variant: 'on', users: ['user:abc'], priority: 10 }
+           ];
+         RETURN fn::feature::materialize('ab');");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'ab' AND user = user:abc;")
+            .contains("\"on\""),
+        "allowlisted user should win over the 0% rollout"
+    );
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'ab' AND user = user:xyz;")
+            .contains("\"off\""),
+        "non-allowlisted user should fall through to the default"
+    );
+
+    // ---- payload resolves for the chosen variant -----------------------
+    sql("CREATE _00_feature_flag SET key = 'pl', enabled = true, default_variant = 'off',
+           variants = ['off','treatment'],
+           rules = [{ kind: 'allowlist', variant: 'treatment', users: ['user:abc'], priority: 10 }],
+           payloads = { treatment: { copy: 'Hello' } };
+         RETURN fn::feature::materialize('pl');");
+    let payload =
+        sql("SELECT variant, payload FROM _00_user_feature WHERE key = 'pl' AND user = user:abc;");
+    assert!(
+        payload.contains("treatment") && payload.contains("Hello"),
+        "payload did not resolve for the chosen variant: {payload}"
+    );
+
+    // ---- rollout bucketing agrees with the hash ------------------------
+    // alice hashes to 8 for 'checkout-v2', so a 10% rollout must include her.
+    sql("CREATE _00_feature_flag SET key = 'checkout-v2', enabled = true, default_variant = 'off',
+           variants = ['off','on'],
+           rules = [{ kind: 'rollout', variant: 'on', percent: 10, priority: 50 }];
+         RETURN fn::feature::materialize('checkout-v2');");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'checkout-v2' AND user = user:alice;")
+            .contains("\"on\""),
+        "rollout bucketing disagrees with fn::feature::hash (alice hashes to 8, under 10%)"
+    );
+
+    // ---- equal priorities keep declaration order -----------------------
+    // Rust sorts with the stable `sort_by_key`, so the first rule wins.
+    sql("CREATE _00_feature_flag SET key = 'tie', enabled = true, default_variant = 'off',
+           variants = ['off','first','second'],
+           rules = [
+             { kind: 'allowlist', variant: 'first', users: ['user:abc'] },
+             { kind: 'allowlist', variant: 'second', users: ['user:abc'] }
+           ];
+         RETURN fn::feature::materialize('tie');");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'tie' AND user = user:abc;")
+            .contains("\"first\""),
+        "equal priorities must keep declaration order (stable sort)"
+    );
+
+    // ---- allow() / disallow() round trip -------------------------------
+    sql("RETURN fn::feature::allow('ab', 'on', user:xyz);");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'ab' AND user = user:xyz;")
+            .contains("\"on\""),
+        "fn::feature::allow should assign and re-materialize"
+    );
+    sql("RETURN fn::feature::disallow('ab', user:xyz);");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'ab' AND user = user:xyz;")
+            .contains("\"off\""),
+        "fn::feature::disallow should revoke and re-materialize"
+    );
+
+    // ---- unknown flag drops orphaned assignments -----------------------
+    let gone = sql("RETURN fn::feature::materialize('does-not-exist');");
+    assert!(
+        gone.contains("false"),
+        "materializing an unknown flag should report found: false, got {gone}"
+    );
+
+    // ---- the user-count guard fires ------------------------------------
+    // `SELECT VALUE id FROM user` runs under the CALLER's permissions, so an
+    // app that hides users would silently materialize almost nobody. The
+    // scheduler stamps the true count for exactly this check.
+    sql("UPSERT _00_module_state:feature_user_count SET count = 99;");
+    let throttled = sql("RETURN fn::feature::materialize('ab');");
+    assert!(
+        throttled.contains("can only see"),
+        "the user-count guard did not fire: {throttled}"
+    );
+    sql("DELETE _00_module_state:feature_user_count;");
+}
+
+#[test]
+#[ignore = "requires Docker; run with: cargo test -p sp00ky-cli --test feature_materialize_e2e -- --ignored"]
+fn only_admins_can_read_or_change_flags() {
+    if !docker_available() {
+        eprintln!("skipping feature_materialize_e2e: Docker is not available");
+        return;
+    }
+    let _guard = start_surrealdb();
+    seed_schema();
+
+    let admin_token = signup("adm");
+    let user_token = signup("reg");
+
+    sql("CREATE _00_feature_flag SET key = 'beta', enabled = true, default_variant = 'off',
+           variants = ['off','on'], rules = [];
+         LET $a = (SELECT VALUE id FROM ONLY user WHERE username = 'adm' LIMIT 1);
+         UPSERT _00_admin SET user = $a WHERE user = $a;
+         RETURN fn::feature::materialize('beta');");
+
+    // ---- non-admin ------------------------------------------------------
+    let flags = sql_as(&user_token, "SELECT * FROM _00_feature_flag;");
+    assert!(
+        !flags.contains("\"beta\""),
+        "a non-admin must not see flag definitions (targeting rules leak otherwise): {flags}"
+    );
+    let roster = sql_as(&user_token, "SELECT * FROM _00_admin;");
+    assert!(
+        !roster.contains("_00_admin:"),
+        "a non-admin must not see the admin roster: {roster}"
+    );
+    assert!(
+        sql_as(&user_token, "RETURN fn::feature::materialize('beta');").contains("permission"),
+        "a non-admin must not be able to call fn::feature::materialize"
+    );
+    assert!(
+        sql_as(&user_token, "RETURN fn::feature::allow('beta','on', $auth.id);")
+            .contains("permission"),
+        "a non-admin must not be able to call fn::feature::allow"
+    );
+
+    // A denied write is a silent no-op in SurrealDB, so assert the DATA, not
+    // the response: this is the check that stops self-enabling a flag.
+    sql_as(
+        &user_token,
+        "UPSERT _00_user_feature SET user = $auth.id, key = 'beta', variant = 'HACKED' \
+         WHERE key = 'beta' AND user = $auth.id;",
+    );
+    sql_as(&user_token, "CREATE _00_admin SET user = $auth.id;");
+    let after = sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'beta';");
+    assert!(
+        !after.contains("HACKED"),
+        "a non-admin forged a _00_user_feature row: {after}"
+    );
+    let roster_count = sql("SELECT count() FROM _00_admin GROUP ALL;");
+    assert!(
+        roster_count.contains("\"count\":1"),
+        "a non-admin promoted themselves into _00_admin: {roster_count}"
+    );
+
+    // Their OWN assignment stays readable — that is what `client.feature()` uses.
+    assert!(
+        sql_as(&user_token, "SELECT key FROM _00_user_feature;").contains("beta"),
+        "a user must still be able to read their own assignment"
+    );
+
+    // ---- admin ----------------------------------------------------------
+    assert!(
+        sql_as(&admin_token, "SELECT key FROM _00_feature_flag;").contains("beta"),
+        "an admin must be able to read flag definitions"
+    );
+    let allow = sql_as(
+        &admin_token,
+        "LET $r = (SELECT VALUE id FROM ONLY user WHERE username = 'reg' LIMIT 1);
+         RETURN fn::feature::allow('beta', 'on', $r);",
+    );
+    assert!(all_ok(&allow), "an admin must be able to allowlist a user: {allow}");
+    assert!(
+        sql("SELECT VALUE variant FROM _00_user_feature WHERE key = 'beta' AND user.username = 'reg';")
+            .contains("\"on\""),
+        "the admin's change did not reach the other user's assignment"
+    );
+
+    // Even an admin cannot grow the roster — that stays root-only (`spky admin`).
+    sql_as(&admin_token, "CREATE _00_admin SET user = $auth.id;");
+    let roster_count = sql("SELECT count() FROM _00_admin GROUP ALL;");
+    assert!(
+        roster_count.contains("\"count\":1"),
+        "an admin was able to write _00_admin: {roster_count}"
+    );
+}

--- a/apps/devtools/src/App.tsx
+++ b/apps/devtools/src/App.tsx
@@ -8,6 +8,7 @@ import { TimingTab } from './components/timing/TimingTab';
 import { DatabaseTab } from './components/database/DatabaseTab';
 import { StorageTab } from './components/storage/StorageTab';
 import { AuthTab } from './components/auth/AuthTab';
+import { FlagsTab } from './components/flags/FlagsTab';
 import { VersionsTab } from './components/versions/VersionsTab';
 import { McpTab } from './components/mcp/McpTab';
 
@@ -53,6 +54,12 @@ function AppContent() {
         <div class="tab-content" classList={{ active: activeTab() === 'auth' }}>
           <Show when={activeTab() === 'auth'}>
             <AuthTab />
+          </Show>
+        </div>
+
+        <div class="tab-content" classList={{ active: activeTab() === 'flags' }}>
+          <Show when={activeTab() === 'flags'}>
+            <FlagsTab />
           </Show>
         </div>
 

--- a/apps/devtools/src/components/Tabs.tsx
+++ b/apps/devtools/src/components/Tabs.tsx
@@ -9,6 +9,7 @@ const tabs: { id: TabType; label: string }[] = [
   { id: 'database', label: 'Database' },
   { id: 'storage', label: 'Storage' },
   { id: 'auth', label: 'Auth' },
+  { id: 'flags', label: 'Flags' },
   { id: 'versions', label: 'Versions' },
   { id: 'mcp', label: 'MCP' },
   { id: 'events', label: 'Events' },

--- a/apps/devtools/src/components/flags/FlagsTab.tsx
+++ b/apps/devtools/src/components/flags/FlagsTab.tsx
@@ -1,0 +1,331 @@
+import { createEffect, createMemo, For, Show } from 'solid-js';
+import { useDevTools } from '../../context/DevToolsContext';
+import { JsonView } from '../ui/JsonView';
+import type { FlagRow } from '../../types/devtools';
+
+/**
+ * Two sections, deliberately separate because they have very different blast
+ * radii:
+ *
+ *  - **Local overrides** change what THIS browser resolves. No auth, no
+ *    network, works signed out. Always visible.
+ *  - **Flags** change the flag for EVERY user. Admin only (`spky admin add`),
+ *    enforced by SurrealDB rather than by hiding the UI.
+ */
+export function FlagsTab() {
+  const {
+    flagsSnapshot,
+    flagsError,
+    isFetchingFlags,
+    isMutatingFlag,
+    fetchFlags,
+    setFlagEnabled,
+    setFlagUserVariant,
+    setFlagOverride,
+    clearFlagOverrides,
+  } = useDevTools();
+
+  // The tab body is unmounted while inactive (App.tsx wraps it in <Show>), so
+  // this runs on every open — the snapshot is a point-in-time remote read.
+  createEffect(() => {
+    if (!flagsSnapshot() && !isFetchingFlags()) void fetchFlags();
+  });
+
+  const snap = () => flagsSnapshot();
+  const overrides = () => snap()?.overrides ?? {};
+
+  /**
+   * Rows for the override table: every flag this browser knows about, whether
+   * it came from an assignment, an override, or (for admins) a definition.
+   * A key with only an override still needs a row, otherwise there'd be no way
+   * to clear it.
+   */
+  const overrideRows = createMemo(() => {
+    const s = snap();
+    if (!s) return [];
+    const keys = new Set<string>();
+    for (const a of s.assignments) keys.add(a.key);
+    for (const k of Object.keys(s.overrides)) keys.add(k);
+    for (const f of s.flags) keys.add(f.key);
+
+    return [...keys].sort().map((key) => {
+      const assigned = s.assignments.find((a) => a.key === key)?.variant;
+      const definition = s.flags.find((f) => f.key === key);
+      // Variants come from the definition when we can see it; otherwise infer
+      // what we can, so a non-admin still gets a usable picker.
+      const variants = definition?.variants?.length
+        ? definition.variants
+        : [...new Set(['off', 'on', assigned, s.overrides[key]?.variant].filter(Boolean))];
+      return { key, assigned, override: s.overrides[key]?.variant, variants: variants as string[] };
+    });
+  });
+
+  const statusPill = () => {
+    const s = snap();
+    if (!s) return { label: 'Loading', cls: 'status-initializing' };
+    if (!s.userId) return { label: 'Signed out', cls: 'status-destroyed' };
+    if (s.isAdmin) return { label: 'Admin', cls: 'status-active' };
+    return { label: 'Read-only', cls: 'status-updating' };
+  };
+
+  return (
+    <div class="mcp-container">
+      <div class="mcp-header">
+        <h2>Feature Flags</h2>
+        <div class="mcp-header-controls">
+          <div class={`status-pill ${statusPill().cls}`}>
+            <span class="status-dot" />
+            {statusPill().label}
+          </div>
+          <button
+            class="icon-btn"
+            title="Refresh flags"
+            disabled={isFetchingFlags()}
+            onClick={() => void fetchFlags()}
+          >
+            ⟳
+          </button>
+        </div>
+      </div>
+
+      <Show when={flagsError()}>
+        <div class="storage-health-banner error">{flagsError()}</div>
+      </Show>
+
+      {/* ---- Local overrides ------------------------------------------- */}
+      <div class="mcp-section">
+        <h3>Local overrides</h3>
+        <p class="muted">
+          Forces a variant in this browser only. Nothing is sent to the server, so clearing an
+          override restores whatever the server says. Survives reloads.
+        </p>
+
+        <Show
+          when={overrideRows().length > 0}
+          fallback={
+            <div class="empty-state">
+              No flags seen yet. Assignments arrive once you sign in and the app calls{' '}
+              <code>client.feature(...)</code>.
+            </div>
+          }
+        >
+          <table class="data-table flags-override-table">
+            <thead>
+              <tr>
+                <th>Flag</th>
+                <th>Assigned</th>
+                <th>Override</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <For each={overrideRows()}>
+                {(row) => (
+                  <tr classList={{ 'flags-overridden': !!row.override }}>
+                    <td class="mono">{row.key}</td>
+                    <td class="mono muted">{row.assigned ?? '—'}</td>
+                    <td>
+                      <select
+                        class="flags-variant-select"
+                        value={row.override ?? ''}
+                        onChange={(e) =>
+                          void setFlagOverride(row.key, e.currentTarget.value || null)
+                        }
+                      >
+                        <option value="">(none)</option>
+                        <For each={row.variants}>
+                          {(variant) => <option value={variant}>{variant}</option>}
+                        </For>
+                      </select>
+                    </td>
+                    <td>
+                      <Show when={row.override}>
+                        <button
+                          class="icon-btn"
+                          title="Clear override"
+                          onClick={() => void setFlagOverride(row.key, null)}
+                        >
+                          ✕
+                        </button>
+                      </Show>
+                    </td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+
+          <Show when={Object.keys(overrides()).length > 0}>
+            <button class="btn" onClick={() => void clearFlagOverrides()}>
+              Clear all overrides
+            </button>
+          </Show>
+        </Show>
+      </div>
+
+      {/* ---- Remote flags (admin only) --------------------------------- */}
+      <div class="mcp-section">
+        <h3>Flags (all users)</h3>
+
+        <Show when={snap()?.isAdmin} fallback={<AdminFallback />}>
+          <p class="muted">
+            Changes here apply to <strong>every user</strong> and take effect live. Creating,
+            deleting and percentage rollouts stay with <code>spky flag</code>.
+          </p>
+
+          <Show
+            when={(snap()?.flags.length ?? 0) > 0}
+            fallback={
+              <div class="empty-state">
+                No flags defined. Create one with <code>spky flag create &lt;key&gt;</code>.
+              </div>
+            }
+          >
+            <For each={snap()!.flags}>
+              {(flag) => (
+                <FlagCard
+                  flag={flag}
+                  busy={isMutatingFlag() === flag.key}
+                  anyBusy={isMutatingFlag() !== null}
+                  onToggle={(enabled) => void setFlagEnabled(flag.key, enabled)}
+                  onVariant={(variant, remove) =>
+                    void setFlagUserVariant(flag.key, variant, remove)
+                  }
+                />
+              )}
+            </For>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Why the admin section is empty. These are four genuinely different problems
+ * with four different fixes, so they must not collapse into one empty state.
+ */
+function AdminFallback() {
+  const { flagsSnapshot, flagsError } = useDevTools();
+  const s = () => flagsSnapshot();
+
+  return (
+    <Show when={s()} fallback={<div class="empty-state">Loading…</div>}>
+      <Show
+        when={s()!.userId}
+        fallback={
+          <div class="empty-state">
+            Sign in to manage flags. Local overrides above work while signed out.
+          </div>
+        }
+      >
+        <Show
+          when={!flagsError()}
+          fallback={
+            <div class="empty-state">
+              Couldn't reach the flag tables. If this deployment predates the Flags tab, run{' '}
+              <code>spky migrate</code> (or redeploy) to apply the internal schema.
+            </div>
+          }
+        >
+          <div class="empty-state">
+            You're not an admin, so flag definitions are hidden from this client. Grant access with{' '}
+            <code class="mono">spky admin add {shortUser(s()!.userId!)}</code>.
+          </div>
+        </Show>
+      </Show>
+    </Show>
+  );
+}
+
+function shortUser(id: string): string {
+  return id.startsWith('user:') ? id : `user:${id}`;
+}
+
+function FlagCard(props: {
+  flag: FlagRow;
+  busy: boolean;
+  anyBusy: boolean;
+  onToggle: (enabled: boolean) => void;
+  onVariant: (variant: string, remove: boolean) => void;
+}) {
+  const allowlisted = () => props.flag.selfAllowlistedVariant;
+
+  return (
+    <div class="flags-card" classList={{ 'flags-busy': props.busy }}>
+      <div class="flags-card-head">
+        <span class="mono flags-key">{props.flag.key}</span>
+        <label class="mcp-toggle" title="Enable/disable for all users">
+          <input
+            type="checkbox"
+            checked={props.flag.enabled}
+            // Disabled while ANY flag is mutating: materialize writes
+            // `_00_user_feature` rows under a UNIQUE (user, key) index, and
+            // overlapping runs can collide.
+            disabled={props.anyBusy}
+            onChange={(e) => props.onToggle(e.currentTarget.checked)}
+          />
+          <span class="mcp-toggle-slider" />
+        </label>
+      </div>
+
+      <Show when={props.flag.description}>
+        <p class="muted">{props.flag.description}</p>
+      </Show>
+
+      <div class="kv">
+        <div class="kv-row">
+          <span class="kv-k">Default</span>
+          <span class="kv-v mono">{props.flag.default_variant}</span>
+        </div>
+        <div class="kv-row">
+          <span class="kv-k">You</span>
+          <span class="kv-v mono">
+            {allowlisted() ? `allowlisted → ${allowlisted()}` : 'not allowlisted'}
+          </span>
+        </div>
+        <Show when={props.flag.updated_at}>
+          <div class="kv-row">
+            <span class="kv-k">Updated</span>
+            <span class="kv-v mono muted">{props.flag.updated_at}</span>
+          </div>
+        </Show>
+      </div>
+
+      <div class="flags-variant-group">
+        <span class="kv-k">Set for me:</span>
+        <For each={props.flag.variants}>
+          {(variant) => (
+            <button
+              class="btn"
+              classList={{ 'flags-variant-active': allowlisted() === variant }}
+              disabled={props.anyBusy}
+              onClick={() => props.onVariant(variant, false)}
+            >
+              {variant}
+            </button>
+          )}
+        </For>
+        <Show when={allowlisted()}>
+          <button
+            class="btn delete-btn"
+            disabled={props.anyBusy}
+            onClick={() => props.onVariant(allowlisted()!, true)}
+          >
+            Remove me
+          </button>
+        </Show>
+      </div>
+
+      <Show when={props.flag.rules.length > 0 || props.flag.payloads}>
+        <details class="detail-section">
+          <summary>Rules &amp; payloads</summary>
+          <JsonView
+            value={{ rules: props.flag.rules, payloads: props.flag.payloads }}
+            class="row-pane-json"
+          />
+        </details>
+      </Show>
+    </div>
+  );
+}

--- a/apps/devtools/src/context/DevToolsContext.tsx
+++ b/apps/devtools/src/context/DevToolsContext.tsx
@@ -14,6 +14,7 @@ import {
   type ChromeMessage,
   type QueryMark,
   type StorageInfo,
+  type FlagsSnapshot,
 } from '../types/devtools';
 import { useChromeConnection } from '../hooks/useChromeConnection';
 import { useRunInHostPage } from '../hooks/useRunInHostPage';
@@ -56,6 +57,18 @@ interface DevToolsContextValue {
   isFetchingStorage: () => boolean;
   fetchStorageInfo: (opts?: { tableCounts?: boolean }) => Promise<void>;
   requestPersistentStorage: () => Promise<boolean>;
+
+  // Flags tab
+  flagsSnapshot: () => FlagsSnapshot | null;
+  flagsError: () => string | null;
+  isFetchingFlags: () => boolean;
+  /** Flag key currently being mutated, so its row can be disabled. */
+  isMutatingFlag: () => string | null;
+  fetchFlags: () => Promise<void>;
+  setFlagEnabled: (key: string, enabled: boolean) => Promise<void>;
+  setFlagUserVariant: (key: string, variant: string, remove: boolean) => Promise<void>;
+  setFlagOverride: (key: string, variant: string | null) => Promise<void>;
+  clearFlagOverrides: () => Promise<void>;
 }
 
 /** Union of two table-name lists, preserving `a`'s order then appending new `b`. */
@@ -103,6 +116,12 @@ export const DevToolsProvider: ParentComponent = (props) => {
   const [storageInfo, setStorageInfo] = createSignal<StorageInfo | null>(null);
   const [storageInfoError, setStorageInfoError] = createSignal<string | null>(null);
   const [isFetchingStorage, setIsFetchingStorage] = createSignal(false);
+  // Flags tab: on-demand too. Definitions aren't synced to the client, so this
+  // is a remote read and can't ride the push channel.
+  const [flagsSnapshot, setFlagsSnapshot] = createSignal<FlagsSnapshot | null>(null);
+  const [flagsError, setFlagsError] = createSignal<string | null>(null);
+  const [isFetchingFlags, setIsFetchingFlags] = createSignal(false);
+  const [isMutatingFlag, setIsMutatingFlag] = createSignal<string | null>(null);
   const [mcpStatus, setMcpStatus] = createSignal<McpStatus>({ enabled: false, connected: false, port: 9315 });
 
   // Custom hooks
@@ -202,6 +221,7 @@ export const DevToolsProvider: ParentComponent = (props) => {
 
       case 'SP00KY_QUERY_RESPONSE':
       case 'SP00KY_STORAGE_INFO_RESPONSE':
+      case 'SP00KY_FLAG_RESPONSE':
         settlePending(message as any);
         break;
 
@@ -219,6 +239,10 @@ export const DevToolsProvider: ParentComponent = (props) => {
         // "Preserve log").
         seenQueryUpdates.clear();
         setQueryMarks([]);
+        // The flag snapshot is tied to the old page's auth session and local
+        // store, so it's stale by definition. Drop it rather than render it.
+        setFlagsSnapshot(null);
+        setFlagsError(null);
         setTimeout(() => {
           checkSp00ky();
         }, 500);
@@ -368,6 +392,11 @@ export const DevToolsProvider: ParentComponent = (props) => {
     // the tab that shows it.
     if (activeTab() === 'storage') {
       void fetchStorageInfo();
+    }
+    // Same on-demand deal for flags: a remote read, only worth it when the
+    // tab that shows it is open.
+    if (activeTab() === 'flags') {
+      void fetchFlags();
     }
   }
 
@@ -592,6 +621,133 @@ export const DevToolsProvider: ParentComponent = (props) => {
     }
   };
 
+  /**
+   * Dispatch a flag op into the page and await the correlated response.
+   *
+   * 30s, not the 15s storage budget or the 10s query one: a write calls
+   * `fn::feature::materialize`, which re-evaluates the flag for EVERY user and
+   * upserts a row each. That is O(users) server-side work in one statement.
+   */
+  const flagOpRequest = (
+    op: 'list' | 'setEnabled' | 'setUserVariant' | 'setOverride' | 'clearOverrides',
+    args?: Record<string, unknown>
+  ) => {
+    return new Promise<any>((resolve, reject) => {
+      const requestId = Math.random().toString(36).substring(7);
+
+      const timeoutId = setTimeout(() => {
+        if (pendingQueries.has(requestId)) {
+          pendingQueries.delete(requestId);
+          reject('Flag request timed out (30s)');
+        }
+      }, 30000);
+
+      pendingQueries.set(requestId, {
+        resolve: (data) => {
+          clearTimeout(timeoutId);
+          resolve(data);
+        },
+        reject: (err) => {
+          clearTimeout(timeoutId);
+          reject(err || 'Undefined error passed to pendingQueries.reject');
+        },
+      });
+
+      hostPage.flagOp(
+        op,
+        requestId,
+        args,
+        (result) => {
+          if (result && !result.success) {
+            clearTimeout(timeoutId);
+            pendingQueries.delete(requestId);
+            reject(result.error || 'Failed to dispatch flag event');
+          }
+        },
+        (err) => {
+          clearTimeout(timeoutId);
+          pendingQueries.delete(requestId);
+          reject(err instanceof Error ? err.message : String(err));
+        }
+      );
+    });
+  };
+
+  const fetchFlags = async () => {
+    if (isFetchingFlags()) return;
+    setIsFetchingFlags(true);
+    try {
+      const data = (await flagOpRequest('list')) as FlagsSnapshot;
+      setFlagsSnapshot(data);
+      // `snapshot.error` is a per-section failure (not migrated, remote read
+      // denied) that still carries a usable local half — surface it without
+      // discarding the snapshot.
+      setFlagsError(data?.error ?? null);
+    } catch (e) {
+      setFlagsError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsFetchingFlags(false);
+    }
+  };
+
+  /**
+   * Run a remote flag mutation, then re-read.
+   *
+   * Serialized on `isMutatingFlag`: `_00_user_feature` has a UNIQUE (user, key)
+   * index, so two overlapping materializes on one flag can collide, and a
+   * failed statement inside the function's FOR loop aborts the rest of it.
+   */
+  const mutateFlag = async (
+    key: string,
+    op: 'setEnabled' | 'setUserVariant',
+    args: Record<string, unknown>
+  ) => {
+    if (isMutatingFlag()) return;
+    setIsMutatingFlag(key);
+    try {
+      const result = await flagOpRequest(op, { key, ...args });
+      if (result && result.success === false) {
+        setFlagsError(result.error || 'Flag update failed');
+      } else {
+        setFlagsError(null);
+      }
+    } catch (e) {
+      setFlagsError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsMutatingFlag(null);
+      await fetchFlags();
+    }
+  };
+
+  const setFlagEnabled = (key: string, enabled: boolean) =>
+    mutateFlag(key, 'setEnabled', { enabled });
+
+  const setFlagUserVariant = (key: string, variant: string, remove: boolean) =>
+    mutateFlag(key, 'setUserVariant', { variant, remove });
+
+  /** Local-only: no auth, no network, works signed out. */
+  const setFlagOverride = async (key: string, variant: string | null) => {
+    try {
+      const result = await flagOpRequest('setOverride', { key, variant });
+      setFlagsSnapshot((prev) =>
+        prev ? { ...prev, overrides: result?.overrides ?? prev.overrides } : prev
+      );
+    } catch (e) {
+      setFlagsError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const clearFlagOverrides = async () => {
+    try {
+      const result = await flagOpRequest('clearOverrides');
+      setFlagsSnapshot((prev) =>
+        prev ? { ...prev, overrides: result?.overrides ?? {} } : prev
+      );
+    } catch (e) {
+      setFlagsError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
   const requestPersistentStorage = async (): Promise<boolean> => {
     try {
       const result = await storageOpRequest('persist');
@@ -755,6 +911,15 @@ export const DevToolsProvider: ParentComponent = (props) => {
     isFetchingStorage,
     fetchStorageInfo,
     requestPersistentStorage,
+    flagsSnapshot,
+    flagsError,
+    isFetchingFlags,
+    isMutatingFlag,
+    fetchFlags,
+    setFlagEnabled,
+    setFlagUserVariant,
+    setFlagOverride,
+    clearFlagOverrides,
   };
 
   return <DevToolsContext.Provider value={contextValue}>{props.children}</DevToolsContext.Provider>;

--- a/apps/devtools/src/hooks/useRunInHostPage.ts
+++ b/apps/devtools/src/hooks/useRunInHostPage.ts
@@ -225,12 +225,50 @@ export function useRunInHostPage() {
     );
   };
 
+  /**
+   * Feature flag read/write (Flags tab). Same eval-dispatch-only contract as
+   * `storageOp`: page-script.ts awaits the async work and posts a
+   * SP00KY_FLAG_RESPONSE correlated by requestId.
+   *
+   * `args` is JSON-serialized rather than interpolated. Unlike storage ops it
+   * carries user-visible strings — flag keys, variants, user record ids — that
+   * come from the database, so string concatenation here would be an eval
+   * injection.
+   */
+  const flagOp = (
+    op: 'list' | 'setEnabled' | 'setUserVariant' | 'setOverride' | 'clearOverrides',
+    requestId: string,
+    args: Record<string, unknown> | undefined,
+    onSuccess: (result: { success: boolean; error?: string }) => void,
+    onError?: (error: any) => void
+  ): void => {
+    run(
+      `(function() {
+        try {
+            window.dispatchEvent(new CustomEvent('SP00KY_FLAG_OP', {
+                detail: {
+                    requestId: '${requestId}',
+                    op: '${op}',
+                    args: ${JSON.stringify(args ?? null)}
+                }
+            }));
+            return { success: true, started: true };
+        } catch (error) {
+            var msg = error instanceof Error ? error.message : String(error);
+            return { success: false, error: msg || 'Unknown caught error in eval dispatch' };
+        }
+      })()`,
+      { onSuccess, onError }
+    );
+  };
+
   return {
     run,
     getSp00kyState,
     getTableData,
     runQuery,
     storageOp,
+    flagOp,
     updateTableRow,
     deleteTableRow,
     clearHistory,

--- a/apps/devtools/src/page-script.ts
+++ b/apps/devtools/src/page-script.ts
@@ -139,6 +139,69 @@
     }
   });
 
+  // Feature flags (Flags tab). Same shape as SP00KY_STORAGE_OP: one listener,
+  // an `op` discriminator, and `args` passed as a JSON object rather than
+  // concatenated into the eval string — flag keys and user record ids come
+  // from the database, so they must never become code.
+  window.addEventListener('SP00KY_FLAG_OP', async (event: any) => {
+    const { requestId, op, args } = event.detail;
+    const sp00ky = (window as any).__00__;
+
+    const respond = (payload: { success: boolean; data?: any; error?: string }) => {
+      window.postMessage(
+        {
+          type: 'SP00KY_FLAG_RESPONSE',
+          source: 'sp00ky-devtools-page',
+          requestId,
+          ...payload,
+        },
+        '*'
+      );
+    };
+
+    const methodByOp: Record<string, string> = {
+      list: 'getFlags',
+      setEnabled: 'setFlagEnabled',
+      setUserVariant: 'setFlagUserVariant',
+      setOverride: 'setLocalFlagOverride',
+      clearOverrides: 'clearLocalFlagOverrides',
+    };
+    const name = methodByOp[op];
+    // Version skew: a panel newer than the page's core. Without this the
+    // promise on the panel side hangs until its timeout with no explanation.
+    if (!name || typeof sp00ky?.[name] !== 'function') {
+      respond({
+        success: false,
+        error: `${name || op} not supported by this core version`,
+      });
+      return;
+    }
+
+    try {
+      const a = args || {};
+      let data;
+      switch (op) {
+        case 'setEnabled':
+          data = await sp00ky.setFlagEnabled(a.key, a.enabled);
+          break;
+        case 'setUserVariant':
+          data = await sp00ky.setFlagUserVariant(a.key, a.variant, a.remove, a.userId);
+          break;
+        case 'setOverride':
+          data = await sp00ky.setLocalFlagOverride(a.key, a.variant, a.payload);
+          break;
+        case 'clearOverrides':
+          data = await sp00ky.clearLocalFlagOverrides();
+          break;
+        default:
+          data = await sp00ky.getFlags();
+      }
+      respond({ success: true, data });
+    } catch (err: any) {
+      respond({ success: false, error: err?.message || String(err) });
+    }
+  });
+
   // Try immediately, then fast retries, then long-tail fallback
   if (!checkForSp00ky()) {
     // Fast retries for normal case

--- a/apps/devtools/src/styles/devtools.css
+++ b/apps/devtools/src/styles/devtools.css
@@ -2681,3 +2681,68 @@ body {
 .database-storage.fallback {
   color: var(--sys-color-error);
 }
+
+/* ===== Flags tab =====
+   Reuses the shared vocabulary (.mcp-container/.mcp-section shell, .kv rows,
+   .data-table, .status-pill, .mcp-toggle, .btn/.icon-btn). Only the bits with
+   no existing equivalent are defined here. */
+
+/* An overridden row is lying to the app relative to the server, so it needs to
+   be obvious at a glance — this is the tab's most confusing failure mode
+   ("why is prod behaving differently for me?"). */
+.flags-override-table tr.flags-overridden {
+  background: color-mix(in srgb, var(--sys-color-primary) 8%, transparent);
+}
+.flags-override-table tr.flags-overridden td:first-child {
+  box-shadow: inset 3px 0 0 var(--sys-color-primary);
+}
+
+.flags-variant-select {
+  width: 100%;
+  padding: 2px 4px;
+  font: inherit;
+  color: var(--sys-color-on-surface);
+  background: var(--sys-color-cdt-base-container);
+  border: 1px solid var(--sys-color-outline);
+  border-radius: var(--sys-radius-sm);
+}
+
+.flags-card {
+  padding: var(--sys-spacing-3);
+  margin-bottom: var(--sys-spacing-3);
+  border: 1px solid var(--sys-color-divider);
+  border-radius: var(--sys-radius-sm);
+  background: var(--sys-color-surface-container-low);
+}
+
+/* A mutation calls fn::feature::materialize, which is O(users) server-side.
+   Dim the card so a slow write doesn't read as a dead UI. */
+.flags-card.flags-busy {
+  opacity: 0.55;
+}
+
+.flags-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sys-spacing-2);
+  margin-bottom: var(--sys-spacing-2);
+}
+
+.flags-key {
+  font-weight: 600;
+}
+
+.flags-variant-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sys-spacing-2);
+  margin-top: var(--sys-spacing-2);
+}
+
+.flags-variant-group .btn.flags-variant-active {
+  color: var(--sys-color-on-surface);
+  background: var(--sys-color-primary-container);
+  border-color: var(--sys-color-primary);
+}

--- a/apps/devtools/src/types/devtools.ts
+++ b/apps/devtools/src/types/devtools.ts
@@ -180,9 +180,68 @@ export type TabType =
   | 'database'
   | 'storage'
   | 'auth'
+  | 'flags'
   | 'mcp'
   | 'versions'
   | 'timing';
+
+// Flags tab types — mirrored from packages/core/src/modules/devtools/flags.ts
+// (the extension deliberately doesn't import core types; keep the shapes in
+// sync by hand).
+
+export interface FlagRule {
+  kind: 'allowlist' | 'rollout' | string;
+  variant: string;
+  /** Allowlist only. Record-id strings, not records. */
+  users?: string[];
+  /** Rollout only, 0..100. */
+  percent?: number;
+  priority: number;
+}
+
+export interface FlagRow {
+  key: string;
+  description?: string;
+  variants: string[];
+  default_variant: string;
+  enabled: boolean;
+  payloads?: Record<string, unknown>;
+  rules: FlagRule[];
+  updated_at?: string;
+  /** The variant the signed-in user is explicitly allowlisted into, if any. */
+  selfAllowlistedVariant?: string;
+}
+
+export interface FlagAssignment {
+  key: string;
+  variant: string;
+  payload?: unknown;
+}
+
+/** A variant forced in this browser only. Never sent to the server. */
+export interface FlagOverride {
+  variant: string;
+  payload?: unknown;
+}
+
+export interface FlagsSnapshot {
+  at: number;
+  userId: string | null;
+  isAdmin: boolean;
+  /** Empty for non-admins — SurrealDB filters the rows rather than erroring. */
+  flags: FlagRow[];
+  assignments: FlagAssignment[];
+  overrides: Record<string, FlagOverride>;
+  /** Set when the schema predates the Flags tab, or the remote read failed. */
+  error?: string;
+}
+
+export interface FlagMutationResult {
+  success: boolean;
+  error?: string;
+  /** Users re-evaluated by `fn::feature::materialize`. */
+  users?: number;
+}
 
 // Storage tab types — mirrored from packages/core/src/modules/devtools/storage-info.ts
 // (the extension deliberately doesn't import core types).

--- a/apps/scheduler/src/feature_flags.rs
+++ b/apps/scheduler/src/feature_flags.rs
@@ -77,6 +77,26 @@ pub async fn tick(db: &Surreal<Client>) -> Result<()> {
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
         .collect();
 
+    // Stamp the root-enumerated user count so `fn::feature::materialize` can
+    // detect a permission-truncated `SELECT VALUE id FROM user`. That function
+    // runs under the CALLER's permissions (a SurrealDB custom function is not
+    // security-definer), so an admin flipping a flag from the DevTools panel
+    // in an app whose `user` table hides rows would silently materialize only
+    // themselves. This sweep is the only place that sees the true count.
+    //
+    // Written after the `flags.is_empty()` early return, so a project with no
+    // flags pays nothing: materialize is only ever called for a flag that
+    // exists, and then the stamp is at most one sweep old.
+    if let Err(err) = db
+        .query("UPSERT _00_module_state:feature_user_count SET count = $count;")
+        .bind(("count", users.len() as i64))
+        .await
+    {
+        // Non-fatal: the guard is a safety net, not a precondition for the
+        // sweep's own work.
+        warn!(error = %err, "Failed to stamp the feature-flag user count");
+    }
+
     if users.is_empty() {
         return Ok(());
     }

--- a/example/e2e/tests/feature-flag-permissions.spec.ts
+++ b/example/e2e/tests/feature-flag-permissions.spec.ts
@@ -7,11 +7,19 @@ import { test, expect } from '@playwright/test';
  * are the foundation of the feature flag system, so their permission
  * guarantees are load-bearing:
  *
- *   _00_feature_flag   - PERMISSIONS NONE: record-token clients cannot
- *                        read targeting rules or write definitions.
+ *   _00_feature_flag   - readable/updatable only by users listed in
+ *                        _00_admin; invisible to everyone else, so
+ *                        targeting rules never reach an ordinary client.
  *   _00_user_feature   - select scoped to WHERE user = $auth.id;
- *                        create/update/delete denied entirely so a
+ *                        create/update/delete open only to admins, so a
  *                        client cannot self-enable a flag.
+ *   _00_admin          - the roster itself. Root-written only (`spky
+ *                        admin`), self-scoped on select, so nobody can
+ *                        promote themselves or enumerate the operators.
+ *
+ * The admin path exists for the DevTools Flags tab. It is deliberately
+ * exercised here too: the interesting property isn't "an admin can", it's
+ * that everything stays shut for everyone else.
  *
  * These tests run against the upstream SurrealDB directly (the same
  * pattern as `waitForThreadInUpstream` in `test-fixtures.ts`).
@@ -116,6 +124,9 @@ test.describe.serial('Feature flag permissions', () => {
       await rootSql(`DELETE _00_feature_flag WHERE key = '${flagKey}';`);
       await rootSql(`DELETE _00_user_feature WHERE key = '${flagKey}';`);
     }
+    // Never leave a test user on the operator roster.
+    if (aliceId) await rootSql(`DELETE _00_admin WHERE user = ${aliceId};`);
+    if (bobId) await rootSql(`DELETE _00_admin WHERE user = ${bobId};`);
   });
 
   test('record-token client cannot CREATE _00_user_feature', async () => {
@@ -200,5 +211,82 @@ test.describe.serial('Feature flag permissions', () => {
     }>;
     expect(bobRows.length, 'bob sees exactly one row').toBe(1);
     expect(bobRows[0]?.variant).toBe('off');
+  });
+
+  // ---- _00_admin -----------------------------------------------------
+
+  test('record-token client cannot see or join the admin roster', async () => {
+    await rootSql(`UPSERT _00_admin SET user = ${aliceId} WHERE user = ${aliceId};`);
+
+    // Bob is not an admin: the roster must be invisible to him, otherwise he
+    // learns who the operators are.
+    const { body: seen } = await recordSql(bobToken, `SELECT * FROM _00_admin;`);
+    expect(
+      ((seen[0]?.result ?? []) as unknown[]).length,
+      'the admin roster must not be enumerable by a non-admin'
+    ).toBe(0);
+
+    // Self-promotion is the whole threat model for this table.
+    await recordSql(bobToken, `CREATE _00_admin SET user = $auth.id;`);
+    const after = (await rootSql(
+      `SELECT count() AS n FROM _00_admin WHERE user = ${bobId} GROUP ALL;`
+    )) as Array<{ result?: Array<{ n: number }> }>;
+    expect(after[0]?.result?.[0]?.n ?? 0, 'bob promoted himself to admin').toBe(0);
+
+    // Alice IS an admin, and still only ever sees her own row.
+    const { body: own } = await recordSql(aliceToken, `SELECT user FROM _00_admin;`);
+    const ownRows = (own[0]?.result ?? []) as Array<{ user?: string }>;
+    expect(ownRows.length, 'an admin sees exactly their own roster row').toBe(1);
+  });
+
+  test('an admin can read and flip flags; a non-admin still cannot', async () => {
+    await rootSql(`DELETE _00_feature_flag WHERE key = '${flagKey}';`);
+    await rootSql(
+      `CREATE _00_feature_flag SET key = '${flagKey}', variants = ['off','on'], default_variant = 'off', rules = [], enabled = true;`
+    );
+    await rootSql(`UPSERT _00_admin SET user = ${aliceId} WHERE user = ${aliceId};`);
+
+    // Read: visible to the admin, still invisible to bob.
+    const { body: aliceSees } = await recordSql(
+      aliceToken,
+      `SELECT key FROM _00_feature_flag WHERE key = '${flagKey}';`
+    );
+    expect(
+      ((aliceSees[0]?.result ?? []) as unknown[]).length,
+      'an admin must be able to read flag definitions'
+    ).toBe(1);
+
+    const { body: bobSees } = await recordSql(
+      bobToken,
+      `SELECT key FROM _00_feature_flag WHERE key = '${flagKey}';`
+    );
+    expect(
+      ((bobSees[0]?.result ?? []) as unknown[]).length,
+      'a non-admin must still see nothing'
+    ).toBe(0);
+
+    // Write: the admin's change must reach BOB's assignment, not just her own.
+    // That round trip is the entire point of the DevTools Flags tab.
+    await recordSql(
+      aliceToken,
+      `RETURN fn::feature::allow('${flagKey}', 'on', ${bobId});`
+    );
+    const bobVariant = (await rootSql(
+      `SELECT VALUE variant FROM _00_user_feature WHERE key = '${flagKey}' AND user = ${bobId};`
+    )) as Array<{ result?: string[] }>;
+    expect(
+      bobVariant[0]?.result?.[0],
+      "an admin's allowlist change must materialize onto the other user"
+    ).toBe('on');
+
+    // And bob cannot call the same function himself.
+    const { body: denied } = await recordSql(
+      bobToken,
+      `RETURN fn::feature::allow('${flagKey}', 'on', $auth.id);`
+    );
+    expect(
+      denied.some((r) => r.status === 'ERR'),
+      `a non-admin must be denied fn::feature::allow, got: ${JSON.stringify(denied)}`
+    ).toBeTruthy();
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export {
   FeatureFlagModule,
   FeatureFlagHandle,
   type FeatureFlagOptions,
+  type FeatureFlagOverride,
   type FeatureFlagSnapshot,
 } from './modules/feature-flag/index';
 export {

--- a/packages/core/src/modules/devtools/flags.ts
+++ b/packages/core/src/modules/devtools/flags.ts
@@ -1,0 +1,349 @@
+/**
+ * Feature flag administration for the DevTools panel.
+ *
+ * Two independent capabilities, deliberately kept apart:
+ *
+ * - **Local overrides** force a variant in THIS browser. No auth, no network,
+ *   works signed out and offline. Delegated straight to `FeatureFlagModule`.
+ * - **Remote changes** flip a flag for EVERY user. These require the caller to
+ *   be listed in `_00_admin` (`spky admin add <user>`); SurrealDB enforces
+ *   that, not this file. A non-admin's SELECT returns `[]` rather than an
+ *   error, and the `fn::feature::*` calls are hard-denied.
+ *
+ * Everything remote goes through `RemoteDatabaseService` with BOUND params.
+ * The panel's generic `runQuery` bridge is not usable here: it interpolates
+ * the SurrealQL into an `inspectedWindow.eval` string (so a DB-sourced flag
+ * key or record id would be concatenated into code) and it rejects after 10s,
+ * which a materialize over a real user table will exceed.
+ *
+ * Definitions live in `_00_feature_flag`, which is NOT synced to clients, so
+ * flags must be read remotely. Per-user assignments live in `_00_user_feature`,
+ * which IS live-synced, so those come from the local store for free.
+ */
+
+import type { Logger } from '../../services/logger/index';
+import { parseRecordIdString } from '../../utils/index';
+
+/**
+ * The only thing this service needs from a database. Structural rather than
+ * `AbstractDatabaseService`, because the local side is a `LocalStore` (which
+ * wraps a database rather than extending it) and both must satisfy it.
+ */
+export interface FlagQueryable {
+  query<T extends unknown[]>(query: string, vars?: Record<string, unknown>): Promise<T>;
+}
+
+/** A targeting rule as written by `spky flag` / `fn::feature::allow`. */
+export interface DevToolsFlagRule {
+  kind: 'allowlist' | 'rollout' | string;
+  variant: string;
+  /** Allowlist only. Stored as record-id STRINGS, not records. */
+  users?: string[];
+  /** Rollout only, 0..100. */
+  percent?: number;
+  priority: number;
+}
+
+export interface DevToolsFlagRow {
+  key: string;
+  description?: string;
+  variants: string[];
+  default_variant: string;
+  enabled: boolean;
+  payloads?: Record<string, unknown>;
+  rules: DevToolsFlagRule[];
+  updated_at?: string;
+  /** Derived: the variant the signed-in user is allowlisted into, if any. */
+  selfAllowlistedVariant?: string;
+}
+
+export interface DevToolsFlagAssignment {
+  key: string;
+  variant: string;
+  payload?: unknown;
+}
+
+export interface DevToolsFlagOverride {
+  variant: string;
+  payload?: unknown;
+}
+
+export interface DevToolsFlagsSnapshot {
+  at: number;
+  /** Null when signed out. */
+  userId: string | null;
+  /** True when `_00_admin` has a row for the signed-in user. */
+  isAdmin: boolean;
+  /** Empty for non-admins — SurrealDB filters the rows, it does not error. */
+  flags: DevToolsFlagRow[];
+  /** From the LOCAL `_00_user_feature`: what this browser actually resolves. */
+  assignments: DevToolsFlagAssignment[];
+  /** Local-only forced variants, page-origin localStorage. */
+  overrides: Record<string, DevToolsFlagOverride>;
+  /**
+   * Set when the internal schema predates this feature (no `_00_admin` table),
+   * or the remote read failed. The panel shows it instead of a bare empty
+   * state, so "not migrated" doesn't look like "you're not an admin".
+   */
+  error?: string;
+}
+
+export interface DevToolsFlagResult {
+  success: boolean;
+  error?: string;
+  /** Users re-evaluated by `fn::feature::materialize`. */
+  users?: number;
+}
+
+/** The slice of `FeatureFlagModule` this service needs. */
+export interface LocalOverrideStore {
+  setLocalOverride(key: string, variant: string | null, payload?: unknown): void;
+  clearLocalOverrides(): void;
+  getLocalOverrides(): Record<string, DevToolsFlagOverride>;
+}
+
+export interface FlagsAdminDeps {
+  remote: FlagQueryable;
+  local: FlagQueryable;
+  logger: Logger;
+  /** Resolves the signed-in user's record id, or null. */
+  currentUserId: () => string | null;
+  /** Set once the client has built its FeatureFlagModule. */
+  overrides: () => LocalOverrideStore | null;
+}
+
+/**
+ * SurrealDB's SDK returns one entry per statement; each entry is the rows for
+ * that statement, but older/local shapes wrap them as `{ status, result }`.
+ * `getTableData` in `index.ts` unwraps the same three shapes inline — this is
+ * that logic, reusable.
+ */
+function statementRows(result: unknown, index = 0): unknown[] {
+  if (!Array.isArray(result)) return [];
+  const entry = result[index];
+  if (Array.isArray(entry)) return entry;
+  if (entry && typeof entry === 'object' && 'result' in entry) {
+    const inner = (entry as { result?: unknown }).result;
+    return Array.isArray(inner) ? inner : inner === undefined || inner === null ? [] : [inner];
+  }
+  return entry === undefined || entry === null ? [] : [entry];
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Row shape guards. `key` is the only field the panel truly can't do without. */
+function hasStringKey(row: unknown): row is { key: string } {
+  return !!row && typeof row === 'object' && typeof (row as { key?: unknown }).key === 'string';
+}
+
+function isAssignment(row: unknown): row is DevToolsFlagAssignment {
+  return hasStringKey(row);
+}
+
+function isFlagRow(row: unknown): row is DevToolsFlagRow {
+  return hasStringKey(row);
+}
+
+export class FlagsAdminService {
+  constructor(private deps: FlagsAdminDeps) {}
+
+  /**
+   * Everything the Flags tab renders, in one round trip per source.
+   *
+   * Each section fails independently: a remote read that throws downgrades to
+   * `isAdmin: false` plus an `error`, while local assignments and overrides
+   * still render. Signing out must not blank the whole tab.
+   */
+  async getFlags(): Promise<DevToolsFlagsSnapshot> {
+    const userId = this.deps.currentUserId();
+    const snapshot: DevToolsFlagsSnapshot = {
+      at: Date.now(),
+      userId,
+      isAdmin: false,
+      flags: [],
+      assignments: [],
+      overrides: this.deps.overrides()?.getLocalOverrides() ?? {},
+    };
+
+    // Local assignments: available signed out and offline.
+    try {
+      const rows = statementRows(
+        await this.deps.local.query('SELECT key, variant, payload FROM _00_user_feature')
+      );
+      snapshot.assignments = rows.filter(isAssignment).map((r) => ({
+        key: r.key,
+        variant: r.variant,
+        payload: r.payload,
+      }));
+    } catch (err) {
+      this.deps.logger.debug(
+        { err, Category: 'sp00ky-client::FlagsAdminService::getFlags' },
+        'Local feature assignments unavailable'
+      );
+    }
+
+    if (!userId) return snapshot;
+
+    try {
+      // Self-scoped by `_00_admin`'s own select rule: an admin sees exactly
+      // their own row, a non-admin sees nothing. The roster never leaks.
+      const admin = statementRows(
+        await this.deps.remote.query('SELECT VALUE id FROM _00_admin WHERE user = $auth.id LIMIT 1')
+      );
+      snapshot.isAdmin = admin.length > 0;
+    } catch (err) {
+      // A missing `_00_admin` table means the deployment hasn't applied the
+      // internal schema yet. Say so — otherwise it reads as "not an admin".
+      snapshot.error = `Could not check admin status: ${message(err)}. If this deployment predates the Flags tab, run \`spky migrate\` (or redeploy) to apply the internal schema.`;
+      return snapshot;
+    }
+
+    if (!snapshot.isAdmin) return snapshot;
+
+    try {
+      const rows = statementRows(
+        await this.deps.remote.query(
+          'SELECT key, description, variants, default_variant, enabled, payloads, rules, updated_at ' +
+            'FROM _00_feature_flag ORDER BY key ASC'
+        )
+      );
+      snapshot.flags = rows
+        .filter(isFlagRow)
+        .map((flag) => ({
+          ...flag,
+          rules: Array.isArray(flag.rules) ? flag.rules : [],
+          variants: Array.isArray(flag.variants) ? flag.variants : [],
+          selfAllowlistedVariant: selfAllowlistedVariant(flag, userId),
+        }));
+    } catch (err) {
+      snapshot.error = `Could not read feature flags: ${message(err)}`;
+    }
+
+    return snapshot;
+  }
+
+  /**
+   * Flip a flag's global `enabled` bit for EVERY user, then re-materialize.
+   *
+   * Both statements are one request so they share a transaction: if the
+   * materialize fails, the `enabled` change rolls back rather than leaving the
+   * definition and the assignments disagreeing.
+   */
+  async setFlagEnabled(key: string, enabled: boolean): Promise<DevToolsFlagResult> {
+    return this.mutate(
+      'UPDATE _00_feature_flag SET enabled = $enabled WHERE key = $key; ' +
+        'RETURN fn::feature::materialize($key);',
+      { key, enabled },
+      1
+    );
+  }
+
+  /**
+   * Add or remove a user from `$key`'s allowlist for `$variant`, then
+   * re-materialize. Defaults to the signed-in user, so the common case
+   * ("turn this on for me, for real") needs no user picker.
+   */
+  async setFlagUserVariant(
+    key: string,
+    variant: string,
+    remove: boolean,
+    userId?: string
+  ): Promise<DevToolsFlagResult> {
+    const target = userId ?? this.deps.currentUserId();
+    if (!target) return { success: false, error: 'Not signed in' };
+
+    // `fn::feature::allow/disallow` declare `$user: record`. A string binding
+    // is rejected by the type check, so parse it into a real RecordId.
+    let user;
+    try {
+      user = parseRecordIdString(target);
+    } catch (err) {
+      return { success: false, error: `Invalid user id '${target}': ${message(err)}` };
+    }
+
+    return remove
+      ? this.mutate('RETURN fn::feature::disallow($key, $user);', { key, user }, 0)
+      : this.mutate('RETURN fn::feature::allow($key, $variant, $user);', { key, variant, user }, 0);
+  }
+
+  setLocalFlagOverride(
+    key: string,
+    variant: string | null,
+    payload?: unknown
+  ): { overrides: Record<string, DevToolsFlagOverride> } {
+    const store = this.deps.overrides();
+    store?.setLocalOverride(key, variant, payload);
+    return { overrides: store?.getLocalOverrides() ?? {} };
+  }
+
+  clearLocalFlagOverrides(): { overrides: Record<string, DevToolsFlagOverride> } {
+    const store = this.deps.overrides();
+    store?.clearLocalOverrides();
+    return { overrides: store?.getLocalOverrides() ?? {} };
+  }
+
+  /**
+   * Run a remote mutation, reporting the materialize count from `$index`.
+   *
+   * Retries on a transaction conflict. `fn::feature::allow` / `disallow` are
+   * read-modify-write over `_00_feature_flag.rules`, so two admins acting on
+   * the same flag at once collide. SurrealDB detects this and fails the loser
+   * with "Transaction conflict ... can be retried" rather than losing the
+   * write — verified against 3.1 — so nothing is silently dropped. Retrying
+   * turns that into the outcome the user expected instead of a raw engine
+   * error they can do nothing with.
+   */
+  private async mutate(
+    sql: string,
+    vars: Record<string, unknown>,
+    index: number
+  ): Promise<DevToolsFlagResult> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MUTATE_ATTEMPTS; attempt++) {
+      try {
+        const result = await this.deps.remote.query(sql, vars);
+        const materialized = statementRows(result, index)[0] as { users?: number } | undefined;
+        return { success: true, users: materialized?.users };
+      } catch (err) {
+        lastError = err;
+        if (!isRetryableConflict(err) || attempt === MUTATE_ATTEMPTS - 1) break;
+        // Staggered so two collided clients don't line up again on the retry.
+        await sleep(40 * (attempt + 1) + Math.random() * 40);
+      }
+    }
+
+    this.deps.logger.warn(
+      { err: lastError, sql, Category: 'sp00ky-client::FlagsAdminService::mutate' },
+      'Feature flag mutation failed'
+    );
+    return { success: false, error: message(lastError) };
+  }
+}
+
+const MUTATE_ATTEMPTS = 3;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRetryableConflict(err: unknown): boolean {
+  return /transaction (write )?conflict/i.test(message(err));
+}
+
+/**
+ * Which variant, if any, this user is explicitly allowlisted into.
+ *
+ * `rules[].users` holds record-id strings (`flag.rs` serialises them as JSON),
+ * so compare as strings. Lets the panel show "you're on the list" without
+ * making the user reason about a raw rules blob.
+ */
+function selfAllowlistedVariant(flag: DevToolsFlagRow, userId: string): string | undefined {
+  const rules = Array.isArray(flag.rules) ? flag.rules : [];
+  const hit = rules.find(
+    (rule) =>
+      rule?.kind === 'allowlist' &&
+      Array.isArray(rule.users) &&
+      rule.users.some((u) => String(u) === userId)
+  );
+  return hit?.variant;
+}

--- a/packages/core/src/modules/devtools/index.ts
+++ b/packages/core/src/modules/devtools/index.ts
@@ -23,6 +23,7 @@ import {
   UNAVAILABLE,
 } from './versions';
 import { walkOpfs, type BlobCacheInfo, type SharedTabsInfo, type StorageInfo } from './storage-info';
+import { FlagsAdminService, type LocalOverrideStore } from './flags';
 
 // Real bundled frontend versions, injected at build time by tsdown's
 // version-define plugin (see tsdown.config.ts). The `typeof` guard keeps these
@@ -85,6 +86,12 @@ export class DevToolsService implements StreamUpdateReceiver {
   private localTablesFetching = false;
   private localTablesAt = 0;
 
+  // Feature flag admin, backing the panel's Flags tab. The local-override
+  // store is injected later (`setFeatureFlagOverrides`) because the
+  // FeatureFlagModule is built after this service.
+  private featureOverrides: LocalOverrideStore | null = null;
+  private readonly flagsAdmin: FlagsAdminService;
+
   constructor(
     private databaseService: LocalStore,
     private remoteDatabaseService: RemoteDatabaseService,
@@ -93,6 +100,18 @@ export class DevToolsService implements StreamUpdateReceiver {
     private authService: AuthService<SchemaStructure>,
     private dataManager?: DataModule<SchemaStructure>
   ) {
+    this.flagsAdmin = new FlagsAdminService({
+      remote: this.remoteDatabaseService,
+      local: this.databaseService,
+      logger: this.logger,
+      currentUserId: () => {
+        const id = this.authService.currentUser?.id;
+        if (!id) return null;
+        return id instanceof RecordId ? encodeRecordId(id) : String(id);
+      },
+      overrides: () => this.featureOverrides,
+    });
+
     this.exposeToWindow();
 
     // Stay dormant until a devtools consumer announces itself. The extension's
@@ -525,11 +544,33 @@ export class DevToolsService implements StreamUpdateReceiver {
     return data;
   }
 
+  /**
+   * Hand the FeatureFlagModule to the Flags tab so it can read and write local
+   * overrides. Called from `Sp00kyClient` once both are constructed; until then
+   * the override methods are no-ops that report an empty map.
+   */
+  public setFeatureFlagOverrides(store: LocalOverrideStore): void {
+    this.featureOverrides = store;
+  }
+
   private exposeToWindow() {
     if (typeof window !== 'undefined') {
       (window as any).__00__ = {
         version: this.version,
         getState: () => this.getState(),
+        // ---- Feature flags (Flags tab) --------------------------------
+        // Remote reads/writes are admin-gated by SurrealDB, not here: a
+        // non-admin gets an empty flag list, and the `fn::feature::*` calls
+        // are denied outright. The override methods are purely local and
+        // work signed out.
+        getFlags: () => this.flagsAdmin.getFlags(),
+        setFlagEnabled: (key: string, enabled: boolean) =>
+          this.flagsAdmin.setFlagEnabled(key, enabled),
+        setFlagUserVariant: (key: string, variant: string, remove: boolean, userId?: string) =>
+          this.flagsAdmin.setFlagUserVariant(key, variant, remove, userId),
+        setLocalFlagOverride: (key: string, variant: string | null, payload?: unknown) =>
+          this.flagsAdmin.setLocalFlagOverride(key, variant, payload),
+        clearLocalFlagOverrides: () => this.flagsAdmin.clearLocalFlagOverrides(),
         clearHistory: () => {
           this.eventsHistory = [];
           this.notifyDevTools();

--- a/packages/core/src/modules/feature-flag/index.test.ts
+++ b/packages/core/src/modules/feature-flag/index.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FeatureFlagModule } from './index';
+
+// vitest runs in the `node` environment here, so there is no localStorage.
+// The module guards every access with `globalThis.localStorage?.`, which keeps
+// overrides in-memory-only — this shim lets the persistence path be tested.
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  const shim = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  (globalThis as any).localStorage = shim;
+  return { store, uninstall: () => delete (globalThis as any).localStorage };
+}
 
 // Minimal mocks for the three deps the module touches. The DataModule mock
 // captures the single subscribe callback so a test can push live results, and
@@ -116,5 +130,122 @@ describe('FeatureFlagModule', () => {
     await tick();
     expect(flag.enabled()).toBe(false); // cleared until the new query resolves
     expect(env.hasSub()).toBe(true); // re-registered for the new user
+  });
+});
+
+// Local overrides force a variant in THIS browser only. They must win over the
+// server assignment on every read path — `variant()`, `payload()`, `enabled()`
+// and `subscribe()` all funnel through the same resolver, so a gap in any one
+// of them is a gap in all of them.
+describe('FeatureFlagModule local overrides', () => {
+  let env: ReturnType<typeof makeDeps>;
+  let mod: FeatureFlagModule<any>;
+  let ls: ReturnType<typeof installLocalStorage>;
+
+  beforeEach(() => {
+    ls = installLocalStorage();
+    env = makeDeps();
+    mod = new FeatureFlagModule(env.deps);
+  });
+
+  afterEach(() => ls.uninstall());
+
+  it('wins over the server assignment', async () => {
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    env.push([{ key: 'alpha', variant: 'off' }]);
+    expect(flag.enabled()).toBe(false);
+
+    mod.setLocalOverride('alpha', 'on');
+    expect(flag.variant()).toBe('on');
+    expect(flag.enabled()).toBe(true);
+  });
+
+  it('survives a later live result for the same key', async () => {
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    mod.setLocalOverride('alpha', 'on');
+
+    env.push([{ key: 'alpha', variant: 'off' }]); // server disagrees
+    expect(flag.variant()).toBe('on');
+  });
+
+  it('applies before the first result, without a fallback flash', () => {
+    mod.setLocalOverride('alpha', 'on');
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    expect(flag.variant()).toBe('on'); // seeded even though nothing loaded yet
+  });
+
+  it('carries its own payload', async () => {
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    env.push([{ key: 'alpha', variant: 'off', payload: { copy: 'server' } }]);
+
+    mod.setLocalOverride('alpha', 'on', { copy: 'local' });
+    expect(flag.payload()).toEqual({ copy: 'local' });
+  });
+
+  it('notifies subscribers when set and cleared', async () => {
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    env.push([{ key: 'alpha', variant: 'off' }]);
+
+    const seen: (string | undefined)[] = [];
+    flag.subscribe((s) => seen.push(s.variant));
+    expect(seen).toEqual(['off']); // immediate call
+
+    mod.setLocalOverride('alpha', 'on');
+    mod.setLocalOverride('alpha', null);
+    expect(seen).toEqual(['off', 'on', 'off']);
+  });
+
+  it('restores the server assignment when cleared', async () => {
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    env.push([{ key: 'alpha', variant: 'treatment', payload: { copy: 'server' } }]);
+
+    mod.setLocalOverride('alpha', 'off');
+    expect(flag.variant()).toBe('off');
+
+    mod.clearLocalOverrides();
+    expect(flag.variant()).toBe('treatment');
+    expect(flag.payload()).toEqual({ copy: 'server' });
+  });
+
+  it('survives a user change — it is a browser setting, not a session one', async () => {
+    mod.init();
+    const flag = mod.feature('alpha', { fallback: 'off' });
+    await tick();
+    mod.setLocalOverride('alpha', 'on');
+
+    env.setUser('user:other');
+    await tick();
+    expect(flag.variant()).toBe('on');
+  });
+
+  it('persists to localStorage and reloads into a fresh module', () => {
+    mod.setLocalOverride('alpha', 'on', { copy: 'local' });
+    expect(mod.getLocalOverrides()).toEqual({ alpha: { variant: 'on', payload: { copy: 'local' } } });
+
+    // A new module reads the same page-origin store, as after a reload.
+    const reloaded = new FeatureFlagModule(makeDeps().deps);
+    expect(reloaded.getLocalOverrides()).toEqual({
+      alpha: { variant: 'on', payload: { copy: 'local' } },
+    });
+    expect(reloaded.feature('alpha', { fallback: 'off' }).variant()).toBe('on');
+  });
+
+  it('drops the storage key entirely once the last override is cleared', () => {
+    mod.setLocalOverride('alpha', 'on');
+    expect(ls.store.size).toBe(1);
+
+    mod.setLocalOverride('alpha', null);
+    expect(ls.store.size).toBe(0);
+    expect(new FeatureFlagModule(makeDeps().deps).getLocalOverrides()).toEqual({});
+  });
+
+  it('ignores a corrupt store rather than failing to construct', () => {
+    ls.store.set('sp00ky:feature-overrides', '{not json');
+    expect(() => new FeatureFlagModule(makeDeps().deps)).not.toThrow();
   });
 });

--- a/packages/core/src/modules/feature-flag/index.ts
+++ b/packages/core/src/modules/feature-flag/index.ts
@@ -13,6 +13,12 @@ import type { QueryTimeToLive } from '../../types';
 // fallback. Avoids one-registration-per-flag and the param-filtered live query.
 const FEATURE_QUERY = 'SELECT key, variant, payload FROM _00_user_feature';
 
+// Local overrides live on the PAGE origin, so they survive reloads and are
+// shared across tabs of the app. Deliberately not the DevTools panel's own
+// storage — the panel runs on a different origin and would get a separate
+// bucket.
+const OVERRIDE_STORAGE_KEY = 'sp00ky:feature-overrides';
+
 interface FeatureRow {
   key?: string;
   variant?: string;
@@ -27,6 +33,16 @@ export interface FeatureFlagSnapshot {
 export interface FeatureFlagOptions {
   fallback?: string;
   ttl?: QueryTimeToLive;
+}
+
+/**
+ * A locally forced variant. Applies to THIS browser only and is never sent to
+ * the server — the assignment in `_00_user_feature` is untouched, so clearing
+ * the override restores whatever the server says.
+ */
+export interface FeatureFlagOverride {
+  variant: string;
+  payload?: unknown;
 }
 
 export class FeatureFlagHandle {
@@ -114,9 +130,15 @@ export class FeatureFlagModule<S extends SchemaStructure> {
   // back). `snapshots` only holds ASSIGNED keys; an absent key → fallback.
   private snapshots = new Map<string, FeatureFlagSnapshot>();
   private loaded = false;
+  // Developer-forced variants, this browser only. Take precedence over the
+  // server assignment for every read path.
+  private overrides = new Map<string, FeatureFlagOverride>();
 
   constructor(private deps: FeatureFlagModuleDeps<S>) {
     this.logger = deps.logger.child({ service: 'FeatureFlagModule' });
+    // Loaded in the constructor rather than `init()` so an override applies
+    // even when `client.feature()` is called before auth resolves.
+    this.loadOverrides();
   }
 
   init(): void {
@@ -135,8 +157,10 @@ export class FeatureFlagModule<S extends SchemaStructure> {
     if (options.ttl) this.ttl = options.ttl;
     // If the shared query already resolved, seed this handle immediately so a
     // late `feature()` call doesn't flash the fallback for an assigned key.
-    if (this.loaded) {
-      handle.set(this.snapshots.get(key) ?? { variant: undefined, payload: undefined });
+    // An override seeds it too, even before the first result: forcing a
+    // variant should take effect instantly, not one round trip later.
+    if (this.loaded || this.overrides.has(key)) {
+      handle.set(this.resolve(key));
     }
     void this.ensureStarted();
     return handle;
@@ -155,8 +179,10 @@ export class FeatureFlagModule<S extends SchemaStructure> {
     this.loaded = false;
     this.snapshots.clear();
     // Clear handles immediately so a sign-out hides flag-gated UI without lag.
+    // `resolve` keeps any local override in place across the switch — it is a
+    // developer setting for this browser, not part of the session.
     for (const handle of this.handles) {
-      handle.set({ variant: undefined, payload: undefined });
+      handle.set(this.resolve(handle.key));
     }
     await this.ensureStarted();
   }
@@ -202,8 +228,81 @@ export class FeatureFlagModule<S extends SchemaStructure> {
       }
     }
     this.loaded = true;
-    for (const handle of this.handles) {
-      handle.set(this.snapshots.get(handle.key) ?? { variant: undefined, payload: undefined });
+    this.pushAll();
+  }
+
+  // ===========================================================
+  // Local overrides (this browser only)
+  // ===========================================================
+
+  /**
+   * Force `key` to `variant` in THIS browser. Pass `null` to clear.
+   *
+   * Nothing is written to the server: the `_00_user_feature` assignment is
+   * untouched, so clearing restores whatever the server says. Persisted to
+   * localStorage on the page origin, so it survives a reload.
+   */
+  setLocalOverride(key: string, variant: string | null, payload?: unknown): void {
+    if (variant === null) this.overrides.delete(key);
+    else this.overrides.set(key, { variant, payload });
+    this.persistOverrides();
+    this.pushAll();
+  }
+
+  clearLocalOverrides(): void {
+    this.overrides.clear();
+    this.persistOverrides();
+    this.pushAll();
+  }
+
+  getLocalOverrides(): Record<string, FeatureFlagOverride> {
+    return Object.fromEntries(this.overrides);
+  }
+
+  /** The assignment for `key`, with any local override taking precedence. */
+  private resolve(key: string): FeatureFlagSnapshot {
+    const override = this.overrides.get(key);
+    if (override) return { variant: override.variant, payload: override.payload };
+    return this.snapshots.get(key) ?? { variant: undefined, payload: undefined };
+  }
+
+  private pushAll(): void {
+    for (const handle of this.handles) handle.set(this.resolve(handle.key));
+  }
+
+  private loadOverrides(): void {
+    try {
+      const raw = globalThis.localStorage?.getItem(OVERRIDE_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Record<string, FeatureFlagOverride>;
+      for (const [key, value] of Object.entries(parsed ?? {})) {
+        if (value && typeof value.variant === 'string') this.overrides.set(key, value);
+      }
+    } catch (err) {
+      // Best-effort: a corrupt or unavailable store must never stop the
+      // client from booting. Same posture as the DevTools prefs helper.
+      this.logger.warn(
+        { err, Category: 'sp00ky-client::FeatureFlagModule::loadOverrides' },
+        'Failed to read local feature flag overrides',
+      );
+    }
+  }
+
+  private persistOverrides(): void {
+    try {
+      if (this.overrides.size === 0) {
+        globalThis.localStorage?.removeItem(OVERRIDE_STORAGE_KEY);
+        return;
+      }
+      globalThis.localStorage?.setItem(
+        OVERRIDE_STORAGE_KEY,
+        JSON.stringify(this.getLocalOverrides()),
+      );
+    } catch (err) {
+      this.logger.warn(
+        { err, Category: 'sp00ky-client::FeatureFlagModule::persistOverrides' },
+        'Failed to persist local feature flag overrides',
+      );
     }
   }
 }

--- a/packages/core/src/sp00ky.ts
+++ b/packages/core/src/sp00ky.ts
@@ -47,7 +47,7 @@ import type { RecordWithId } from './modules/cache/index';
 import { CrdtManager, CrdtField } from './modules/crdt/index';
 import { preloadLoro } from './modules/crdt/loro-loader';
 import { FeatureFlagModule, FeatureFlagHandle } from './modules/feature-flag/index';
-import type { FeatureFlagOptions } from './modules/feature-flag/index';
+import type { FeatureFlagOptions, FeatureFlagOverride } from './modules/feature-flag/index';
 import { AppReleaseModule, AppReleaseHandle } from './modules/app-release/index';
 import type { AppReleaseOptions } from './modules/app-release/index';
 import { LocalStoragePersistenceClient } from './services/persistence/localstorage';
@@ -464,6 +464,11 @@ export class Sp00kyClient<S extends SchemaStructure> {
       this.auth,
       this.dataModule
     );
+
+    // Let the DevTools Flags tab read and write local flag overrides. Done
+    // here rather than via the constructor because FeatureFlagModule is built
+    // above and DevToolsService takes its deps positionally.
+    this.devTools.setFeatureFlagOverrides(this.featureFlags);
 
     // Register DevTools as a receiver for stream updates
     this.streamProcessor.addReceiver(this.devTools);
@@ -1045,6 +1050,31 @@ export class Sp00kyClient<S extends SchemaStructure> {
    */
   feature(key: string, options?: FeatureFlagOptions): FeatureFlagHandle {
     return this.featureFlags.feature(key, options);
+  }
+
+  /**
+   * Force a feature flag to `variant` in THIS browser only; `null` clears it.
+   *
+   * Nothing is sent to the server — the `_00_user_feature` assignment is
+   * untouched, so clearing restores whatever the server says. Persisted to
+   * localStorage, survives reloads, and applies while signed out. Backs the
+   * DevTools Flags tab, and is a convenient hook for tests.
+   *
+   * To change a flag for OTHER users you need admin rights (`spky admin add`)
+   * and the DevTools Flags tab, or `spky flag`.
+   */
+  setFeatureOverride(key: string, variant: string | null, payload?: unknown): void {
+    this.featureFlags.setLocalOverride(key, variant, payload);
+  }
+
+  /** Drop every local feature flag override set via `setFeatureOverride`. */
+  clearFeatureOverrides(): void {
+    this.featureFlags.clearLocalOverrides();
+  }
+
+  /** The local feature flag overrides currently in effect, keyed by flag. */
+  getFeatureOverrides(): Record<string, FeatureFlagOverride> {
+    return this.featureFlags.getLocalOverrides();
   }
 
   /**


### PR DESCRIPTION
## Why

Feature flags could only be changed with `spky flag` from a terminal holding root credentials. A developer running the app in a browser had no way to flip a flag for themselves, and no way to roll one out to other users without dropping to the CLI.

## What

A **Flags** tab in the DevTools extension, with two capabilities kept deliberately apart because their blast radii differ:

| | Scope | Auth |
|---|---|---|
| **Local overrides** | This browser only | None — works signed out and offline |
| **Remote changes** | Every user | Admin |

Remote changes cover the global `enabled` bit and per-user allowlist membership. Creating, deleting and percentage rollouts stay with `spky flag`.

## The admin model

sp00ky had no admin concept, only record tokens and root. The `user` table belongs to the app, so gating on a `role` field would require every app to adopt one *and* hand users a field they could write to promote themselves.

Instead: `_00_admin`, a new internal table written only by root via `spky admin add|remove|list`. It denies `create/update/delete` unconditionally, and its select rule is self-scoped — an admin can confirm their own status without the roster being enumerable.

## Why a materialize function was needed

`_00_user_feature` is already live-synced, but it is *derived*. Writing a definition syncs nothing on its own, and the scheduler sweep skips (user, flag) pairs that already have a row. `fn::feature::materialize` re-evaluates one flag for all users; `allow`/`disallow` edit the allowlist and re-materialize.

## Three SurrealDB behaviours that shaped this

Verified against `surrealdb-core-3.1.5` rather than assumed:

- **Permission-clause subqueries run with checks disabled**, so `_00_admin` can gate other tables while staying invisible itself.
- **`DEFINE FUNCTION` defaults to `PERMISSIONS FULL`.** Omitting the clause does not make a function root-only — it ships a self-service flag editor to every signed-in user. All three mutations carry an explicit clause, and a unit test asserts it.
- **Custom functions are not security-definer**; the body runs as the caller. Hence `_00_user_feature` opening writes to admins, and hence the `SELECT id FROM user` inside materialize being permission-filtered — the scheduler now stamps the root-enumerated user count so materialize throws loudly instead of silently updating only the admin.

## Drive-by fix

`fn::feature::hash` was broken on SurrealDB 3: the int cast no longer accepts hex and hex literals were removed from the language, so `<int>'0x5f7bdee4'` errors. Nothing called it before (both Rust evaluators hash themselves), but every rollout rule would have failed the moment materialize did. Replaced with a hand-rolled hex fold that reproduces the pinned Rust golden vectors exactly.

## Concurrency

`allow`/`disallow` are read-modify-write over the rules array, matching `spky flag`. Concurrent admins collide — but SurrealDB fails the loser with a retryable transaction conflict rather than dropping the write (verified with 4 parallel calls), so the bridge retries with jitter instead of surfacing a raw engine error.

## Tests

- New Docker-backed e2e (`feature_materialize_e2e.rs`, `#[ignore]`, pinned to SurrealDB 3.x): asserts the SurrealQL evaluator matches the Rust golden vectors, and the full permission matrix — a non-admin cannot read definitions, forge a `_00_user_feature` row, or join the roster.
- 10 new unit tests for local overrides.
- The Playwright permission spec gains admin coverage.
- Core 481/481, scheduler 90/90, CLI 393 passing.

## Notes for the reviewer

- **Deployments need the internal schema applied** (`spky migrate` / redeploy) before the tab does anything; until then `getFlags` returns `isAdmin: false` for everyone and the tab says so explicitly. Targets: `threads`, `whitepawn`.
- Not verified by clicking through a loaded extension — the bridge round trip is covered by build + typecheck only. Everything server-side is verified against a live SurrealDB 3.1.
- Two `migrate::tests` fail on this branch, but they **also fail on a clean `main`** — pre-existing and unrelated.
- Two pre-existing issues found and left alone: the `fn::job::kill`/`retry` comment claiming they are root-only (they default to FULL), and the scheduler sweep's skip-if-exists letting a mid-tick signup stick on a stale variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)